### PR TITLE
Extract metadata and article paragraphs for youngcons.com

### DIFF
--- a/misinformation/spiders/spiders.py
+++ b/misinformation/spiders/spiders.py
@@ -162,10 +162,21 @@ class YoungCons(CrawlSpider):
     )
 
     def parse_item(self, response):
-        with open('article_urls/{}.txt'.format(self.name), 'a') as f:
-            # write out the title and add a newline.
-            f.write(response.url + "\n")
-            print(response.url)
+        # Extract article metadata and structured text
+        article = Article()
+        article['site_name'] = self.name
+        article['article_url'] = response.url
+        title = response.css('.td-post-title').xpath('./h1l[@class="entry-title"]/text()').extract_first()
+        if title:
+            article['title'] = title.strip()
+        author = response.css('.td-post-author-name').xpath('./a/text()').extract_first()
+        if author:
+            article["authors"] = [author.strip()]
+        publication_date = response.css('.entry-date').xpath('./@datetime').extract_first()
+        if publication_date:
+            article["publication_date"] = iso8601.parse_date(publication_date)
+        article['content'] = response.css('.td-post-content').xpath('.//p').extract()
+        return article
 
 
 class AddictingInfo(CrawlSpider):


### PR DESCRIPTION
This PR implements alan-turing-institute/misinformation#2 for the youngcons.com spider