### PR TITLE
Update site configs

### DIFF
--- a/site_configs.yml
+++ b/site_configs.yml
@@ -498,8 +498,8 @@ redstatewatcher.com:
 thinkprogress.org:
   site_name: 'thinkprogress.org'
   start_url: 'http://thinkprogress.org'
-  follow_url_path: 'politics/page/'
-  article_url_xpath: '//h2[contains(concat(" ",normalize-space(@class)," ")," post__title ")]/a'
+  follow_url_path: 'tag/'
+  article_url_xpath: '//h2[contains(@class, "post__title")]//a'
   article_search: 'paged'
   article:
     title:
@@ -509,7 +509,7 @@ thinkprogress.org:
     byline:
       select-method: 'xpath'
       select-expression: '//span[@class="post__byline__author"]//a/text()'
-      match-rule: 'single'
+      match-rule: 'concatenate'
     publication_datetime:
       select-method: 'xpath'
       select-expression: '//time[@class="post__date"]/@datetime'


### PR DESCRIPTION
Updates to some site configs to improve their performance at identifying landing pages and/or articles. Previous rules were overly restrictive, resulting in only O(10) articles being extracted in some cases.

- dailykos.com
- breitbart.com
- thinkprogress.org