### PR TITLE
Exclude duplicate pages from nytimes.com

### DIFF
--- a/site_configs.yml
+++ b/site_configs.yml
@@ -571,6 +571,7 @@ nytimes.com:
       url_must_not_contain: '/(video|es|interactive)/'
   article:
     url_must_contain: '/\d\d\d\d/\d\d/\d\d/.*/politics/'
+    url_must_not_contain: '(action=click|module=)'
     title:
       select_method: 'xpath'
       select_expression: '//meta[@property="og:title"]/@content'


### PR DESCRIPTION
Exclude duplicate pages which differ only in the options passed to the server. The ones that we encounter on the crawl can be excluded by rejecting `action=click` and `module=`. Closes #117 