### PR TITLE
Speed up XMLSitemapSpider by removing unnecessary Selenium calls

### DIFF
--- a/misinformation/pipelines/articlejsonfileexporter.py
+++ b/misinformation/pipelines/articlejsonfileexporter.py
@@ -33,6 +33,7 @@ class ArticleJsonFileExporter():
         self.exporter.file.close()
 
     def process_item(self, article, spider):
+        spider.logger.info('  preparing to save response to local file')
         self.exporter.export_item(article)
-        spider.logger.info("Successfully crawled: {}".format(article["article_url"]))
+        spider.logger.info("Finished database export for: {}".format(article["article_url"]))
         return article


### PR DESCRIPTION
Updated index page logic so that `JsLoadButtonMiddleware` is not called in cases where no index_page regexes are specified.

Also made log messages more explicit, since the `XMLSitemapSpider` seems to process several pages in parallel and it cannot be guaranteed that log messages from the same page will stay together.

Closes #171 