### PR TITLE
Updated cnn.com config

### DIFF
--- a/site_configs.yml
+++ b/site_configs.yml
@@ -294,7 +294,7 @@ cnn.com:
     scattergun:
       url_must_not_contain: '/(TRANSCRIPTS|www.cnn.com|videos)/'
   article:
-    url_must_contain: '/\d\d\d\d/\d\d/\d\d/politics/.+/index.html'
+    url_must_contain: '/\d+/(POLITICS|politics)/.+/index.html'
     title:
       select_method: 'xpath'
       select_expression: '//meta[@property="og:title"]/@content'


### PR DESCRIPTION
Included additional pages (under POLITICS instead of politics) and excluded additional pages, including extremely odd (but valid) URLs like `https://edition.cnn.com/videos/us/2015/08/03/drones-airliners-close-calls-terror-threat-brown-dnt-tsr.cnn/video/playlists/all-things-drones/www.cnn.com/profiles/www.cnn.com/profiles/www.cnn.com/profiles/www.cnn.com/shows/www.cnn.com/profiles/www.cnn.com/shows/www.cnn.com/shows/www.cnn.com/shows/www.cnn.com/shows/www.cnn.com/shows/www.cnn.com/profiles/www.cnn.com/shows/www.cnn.com/shows/www.cnn.com/shows/www.cnn.com/profiles/www.cnn.com/shows/www.cnn.com/profiles/www.cnn.com/shows/www.cnn.com/shows/www.cnn.com/shows/www.cnn.com/profiles/www.cnn.com/profiles/www.cnn.com/profiles/www.cnn.com/shows/www.cnn.com/profiles/www.cnn.com/shows/www.cnn.com/shows/www.cnn.com/shows/www.cnn.com/shows/www.cnn.com/profiles/www.cnn.com/profiles/www.cnn.com/shows/www.cnn.com/profiles/www.cnn.com/profiles/www.cnn.com/profiles/pamela-brown-profile`