### PR TITLE
Fix button pressing

### DIFF
--- a/misinformation/middlewares/buttonpressmiddleware.py
+++ b/misinformation/middlewares/buttonpressmiddleware.py
@@ -71,7 +71,6 @@ class ButtonPressMiddleware:
             PressableButton('//input[contains(@class, "agree")]', "Return"),
         ]
         self.load_buttons = [
-            PressableButton('//a[contains(@class, "m-more")]', "Return"),
             PressableButton('//button[@class="btn-more"]', "Return"),
             PressableButton('//button[@phx-track-id="load more"]', "Return"),
             PressableButton('//button[contains(@class, "LoadMoreButton")]', "Return"),

--- a/site_configs.yml
+++ b/site_configs.yml
@@ -1819,7 +1819,7 @@ sputniknews.com:
   crawl_strategy:
     method: 'index_page'
     index_page:
-      url_must_contain: 'sputniknews.com/archive/$'
+      url_must_contain: '/archive/\?id='
       article_links: '//h2[@class="b-plainlist__title"]/a'
   article:
     url_must_contain: '/\d\d\d\d\d\d\d\d'


### PR DESCRIPTION
Fix several issues with button pressing

- Simplified denverpost config to avoid need for button pressing
- Made dailywire button more restrictive (previous button was added in 9033cb8)
- Added check for buttons that may have moved
- Switched sputniknews to use index page (previous button was added in e7deed2f)

Closes #322