### PR TITLE
add extra urls clickhole

### DIFF
--- a/site_configs.yml
+++ b/site_configs.yml
@@ -393,7 +393,10 @@ christianpost.com:
 
 clickhole.com:
   site_name: 'clickhole.com'
-  start_url: 'https://www.clickhole.com/c/news'
+  start_url:
+    - 'https://www.clickhole.com/c/news'
+    - 'https://patriothole.clickhole.com/'
+    - 'https://resistancehole.clickhole.com/'
   crawl_strategy:
     method: 'index_page'
     index_page:


### PR DESCRIPTION
We get a few extra articles, 342 instead of 298 by including these urls:

```
2019-08-05 10:50:06     INFO: Processed 352 pages in 0:01:37.785492 => 3.63 Hz
2019-08-05 10:50:06     INFO: Found articles in 342/352 pages => 97.16%
2019-08-05 10:50:06     INFO: ... of these 0/342 had no date => 0.00%
2019-08-05 10:50:06     INFO: ... of these 0/342 had no byline => 0.00%
2019-08-05 10:50:06     INFO: ... of these 0/342 had no title => 0.00%
2019-08-05 10:50:06     INFO: Including skipped pages, there are articles in 342/352 pages => 97.16%
```