### PR TITLE
only update cookies when present

### DIFF
--- a/misinformation/middlewares/buttonpressmiddleware.py
+++ b/misinformation/middlewares/buttonpressmiddleware.py
@@ -220,10 +220,10 @@ class ButtonPressMiddleware:
         # can be used for future requests
         try:
             cookies = self.driver.get_cookies()
+            if cookies:
+                spider.update_cookies(cookies)
         except WebDriverException:
-            cookies = None
-        if cookies:
-            spider.update_cookies(cookies)
+            pass
         return HtmlResponse(body=html_str, url=request.url, encoding=request.encoding, request=request)
 
     def spider_closed(self):


### PR DESCRIPTION
Closes #346 

Frontpagemag.com can now be crawled

Tested with huffingtonpost.com which saves cookies, crawler works as expected