### PR TITLE
Switch washingtontimes to sitemap crawl and add extra date format

### DIFF
--- a/site_configs.yml
+++ b/site_configs.yml
@@ -2401,6 +2401,7 @@ washingtontimes.com:
       match_rule: 'last'
       datetime_formats:
         - 'dddd MMMM DD YYYY'
+        - 'dddd MMMM D YYYY'
     content:
       select_method: 'xpath'
       select_expression: '//div[@class="storyareawrapper"]'
@@ -2408,6 +2409,7 @@ washingtontimes.com:
       remove_expressions:
         - '//div[@class="permission"]'
         - '//div[h4[contains(text(), "The Washington Times Comment Policy")]]'
+        - '//div[@id="newsletter-form-story"]'
 
 weeklyworldnews.com:
   site_name: 'weeklyworldnews.com'

--- a/tests/site_test_data/washingtontimes.com/article-3_article.html
+++ b/tests/site_test_data/washingtontimes.com/article-3_article.html
@@ -1,0 +1,2653 @@
+
+
+
+
+<!DOCTYPE html><!--[if IE]><![endif]-->
+<!--[if lt IE 7]><html class="ie ie6 ielegacy no-js" lang="en-US"><![endif]-->
+<!--[if IE 7]><html class="ie ie7 ielegacy no-js" lang="en-US"><![endif]-->
+<!--[if IE 8]><html class="ie ie8 ielegacy no-js" lang="en-US"><![endif]-->
+<!--[if IE 9]><html class="ie ie9 no-js" lang="en-US"><![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html class="no-js" lang="en-US">
+<!--<![endif]-->
+<head>
+  <!-- Piano / VX Composer -->
+  <script>
+    document.cookie = "__adblocker=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+    var setNptTechAdblockerCookie = function (adblocker) {
+      var d = new Date();
+      d.setTime(d.getTime() + 60 * 60 * 24 * 2 * 1000);
+      document.cookie = "__adblocker=" + (adblocker ? "true" : "false") + "; expires=" + d.toUTCString() + "; path=/";
+    }
+    var script = document.createElement("script");
+    script.setAttribute("async", true);
+    script.setAttribute("src", "//www.npttech.com/advertising.js");
+    script.setAttribute("onerror", "setNptTechAdblockerCookie(true);");
+    document.getElementsByTagName("head")[0].appendChild(script);
+  </script>
+
+ <script src="https://scripts.webcontentassessor.com/scripts/85d8ddb05bcf089b2c29e59623ae519ad02e2a929bfaac10d875c38b93211525"></script>
+  <script src="//twt-assets.washtimes.com/js/prebid.1.30.0.b69f0415a045.js"></script>
+
+
+   <!-- BEGIN marfeel -->
+    <script>window.mrf={host:"bc.marfeel.com",dt:3},function(e,t,o,a,i,n,r){function s(){l&&(e.cookie="fromt=yes;path=/;expires="+new Date(Date.now()+18e5).toGMTString(),o.reload())}var l=!/marfeelgarda=no|fromt=yes/i.test(n+";"+i);if((/(ipad.*?OS )(?!1_|2_|3_|4_|X)|mozilla.*android (?!(1|2|3)\.)[0-9](?!.*mobile)|\bSilk\b/i.test(a)&&2&r.dt||/(ip(hone|od).*?OS )(?!1_|2_|3_|4_|X)|mozilla.*android (?!(1|2|3)\.)[0-9].*mobile|bb10/i.test(a)&&1&r.dt||/marfeelgarda=off/i.test(n))&&t===t.top){l&&e.write('<plaintext style="display:none">');var m="script",d=setTimeout(s,1e4),c=e.createElement(m),f=e.getElementsByTagName(m)[0];c.src="https://"+t.mrf.host+"/statics/marfeel/gardac.js",c.onerror=s,c.onload=function(){clearTimeout(d)},f.parentNode.insertBefore(c,f)}else{var p=o.pathname.split("/"),m=e.createElement("script");m.src="https://"+t.mrf.host+"/"+o.hostname+(r.multi&&p.length>1&&p[1].length?"/"+p[1]:"")+"/main.d.js",m.async=!0,e.head.appendChild(m)}}(document,window,location,navigator.userAgent,document.cookie,location.search,window.mrf);</script>
+    <script>function getMrfP() {var r=.1,n=.15,t=.2,a=Math.random();return a>r&&n>a?"S":a>r&&t>a?"D":"M"} </script>
+    <!-- END marfeel -->
+
+
+  <script id="js-jquery" src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+
+
+
+    <script>
+  function getRoxotGroupId() {
+    try {
+      var storageKey = 'roxot-gid';
+      var groupId = localStorage.getItem(storageKey);
+      if (groupId === null) {
+        groupId = 1 + Math.floor(Math.random() * 10000);
+        localStorage.setItem(storageKey, groupId);
+      }
+      return '' + groupId;
+    } catch (e) {
+      return '10001';
+    }
+  }
+
+  function getRoxotSectorId() {
+    try {
+      var storageKey = 'roxot-sid';
+      var groupId = localStorage.getItem(storageKey);
+      if (groupId === null) {
+        groupId = 1 + Math.floor(Math.random() * 100);
+        localStorage.setItem(storageKey, groupId);
+      }
+      return '' + groupId;
+    } catch (e) {
+      return '101';
+    }
+  }
+
+  function getRoxotDeep() {
+    try {
+      var storageKey = 'roxot-deep';
+      var groupId = localStorage.getItem(storageKey);
+      if (groupId === null) {
+        groupId = 1 + Math.floor(Math.random() * 100);
+        localStorage.setItem(storageKey, groupId);
+      }
+      return '' + groupId;
+    } catch (e) {
+      return '101';
+    }
+  }
+
+  function getRoxotEvent() {
+    return '' + (1 + Math.floor(Math.random() * 100));
+  }
+</script>
+
+
+    <!-- Load GPT ASYNC --->
+<script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+
+<script>
+   var googletag = googletag || {};
+   googletag.cmd = googletag.cmd || [];
+   googletag.cmd.push(function(){
+
+     googletag.pubads()
+        .setTargeting('roxot-group-id', getRoxotGroupId())
+        .setTargeting('roxot-sector-id', getRoxotSectorId())
+        .setTargeting('roxot-deep', getRoxotDeep())
+        .setTargeting('roxot-event-group-id', getRoxotEvent())
+        .setTargeting('roxot-event', getRoxotEvent())
+        .setTargeting('roxot-event-deep', getRoxotEvent())
+        .setTargeting('roxot-minutes', (new Date()).getUTCMinutes().toString())
+        .setTargeting('roxot-hours', (new Date()).getUTCHours().toString())
+        .setTargeting('roxot-day', (new Date()).getUTCDay().toString());
+
+     console.log('__ADS enableSingleRequest');
+     googletag.pubads().enableSingleRequest();
+     console.log('__ADS disableInitialLoad');
+     googletag.pubads().disableInitialLoad();
+     console.log('__ADS enableServices');
+     googletag.enableServices();
+   });
+
+  window.GPT = {
+    SITE: 'production',
+    ACCOUNT: '/5856/wash.times'
+  };
+  window.GPT.segmentation = document.cookie.match('Segmentation=Preferred') ? 'Preferred' : 'Normal';
+</script>
+
+
+    <script async src="//twt-assets.washtimes.com/js/dart.8ad33fb3ede5.js"></script>
+    <!-- BEGIN: Nativo -->
+    <script type="text/javascript" src="//s.ntv.io/serve/load.js" async></script>
+    <!-- End Nativo Code -->
+
+    <script>
+      //load the apstag.js library
+      !function(a9,a,p,s,t,A,g){if(a[a9])return;function q(c,r){a[a9]._Q.push([c,r])}a[a9]={init:function(){q("i",arguments)},fetchBids:function(){q("f",arguments)},setDisplayBids:function(){},targetingKeys:function(){return[]},_Q:[]};A=p.createElement(s);A.async=!0;A.src=t;g=p.getElementsByTagName(s)[0];g.parentNode.insertBefore(A,g)}("apstag",window,document,"script","//c.amazon-adsystem.com/aax2/apstag.js");
+    </script>
+    <script src="//twt-assets.washtimes.com/js/twt_app.fdf4a3da99fc.js"></script>
+
+
+
+
+
+  <script>
+    window.GPT.path = '/5856/wash.times/police-say-9-year-old-boy-had-stolen-car-that-hit-';
+    window.GPT.cats = JSON.parse('["news", "national"]');
+    window.GPT.slug = 'police-say-9-year-old-boy-had-stolen-car-that-hit-';
+    window.GPT.contenttype = 'story';
+    window.GPT.referred = 'document.referrer.split(' / ')[2]';
+
+
+
+  </script>
+
+
+
+
+    <script src="//twt-assets.washtimes.com/v4/js/ads/config/story.49a5e0957f92.js"></script>
+
+
+
+
+	<!-- Begin comScore Tag -->
+  <script>
+    var _comscore = _comscore || [];
+    _comscore.push({ c1: "2", c2: "17692074", c3: "", c4: "www.washingtontimes.com/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/" });
+    (function() {
+      var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+      s.src = (document.location.protocol == "https:" ? "https://sb" : "http://b") + ".scorecardresearch.com/beacon.js";
+      el.parentNode.insertBefore(s, el);
+    })();
+  </script>
+  <noscript>
+    <img src="//b.scorecardresearch.com/p?c1=2&c2=17692074&c3=&c4=www.washingtontimes.com/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/&c5=&c6=&c15=&cv=2.0&cj=1" />
+  </noscript>
+	<!-- End comScore Tag -->
+
+
+
+  <!-- BEGIN onesignal -->
+  <script src="https://cdn.onesignal.com/sdks/OneSignalSDK.js" async='async'></script>
+  <script>
+    var OneSignal = window.OneSignal || [];
+    OneSignal.push(["init", {
+      appId: '90fa34ea-9c30-4657-83d5-14b0f91fb62c',
+      autoRegister: true,
+      subdomainName: 'washtimes',
+      safari_web_id: 'web.onesignal.auto.11181d92-f3cb-414e-9b3e-6471e643153c',
+      httpPermissionRequest: {
+        enable: true
+      },
+      notifyButton: {
+        enable: false
+      }
+    }]);
+  </script>
+  <!-- END onesignal -->
+
+
+	<title>Police say 9-year-old boy had stolen car that hit house - Washington Times</title>
+
+
+		<meta name="description" content="Police have cited a 9-year-old boy who officers say stole a car, lost control of it and crashed into a Grand Island house." />
+
+
+
+	<meta charset="UTF-8" />
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+	<meta name="bitly-verification" content="d180fd45f70d" />
+	<meta property="fb:app_id" content="877559545760875" />
+  <meta name="msvalidate.01" content="5B44585918D69318CA2120B5FA20D85C" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta http-equiv="X-UA-Compatible" content="chrome=1" />
+	<meta http-equiv="x-rim-auto-match" content="none" />
+	<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes" />
+	<meta name="format-detection" content="telephone=no" />
+	<meta name="author" content="The Washington Times http://www.washingtontimes.com" />
+  <meta name="serverf" content="web0" />
+
+
+
+  <!-- Pinterest Verify Code -->
+  <meta name="p:domain_verify" content="a57fa64b791c3f2c004bf337ea4b54da" />
+  <!-- END Pinterest Verify Code -->
+  <!-- Pinterest Tracking Code -->
+  <script type="text/javascript"> !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version="3.0";var t=document.createElement("script");t.async=!0,t.src=e;var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r)}}("https://s.pinimg.com/ct/core.js");  pintrk('load','2614346040902'); pintrk('page', { page_name: 'My Page', page_category: 'My Page Category' }); </script> <noscript> <img height="1" width="1" style="display:none;" alt="" src="https://ct.pinterest.com/v3/?tid=2614346040902&noscript=1" /> </noscript>
+  <!-- END Pinterest Tracking Code -->
+  <!-- Pinterest Event Code -->
+  <script>
+  pintrk('track', 'pagevisit' , {
+    promo_code: 'TWTCHACKAPINT'
+  });
+  </script>
+  <!-- END Pinterest Event Code -->
+
+
+  <link rel="amphtml" href="http://amp.washingtontimes.com/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/">
+  <meta property="article:section" content="National"/>
+  <link rel="canonical" href="https://www.washingtontimes.com/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/"/>
+  <meta name="Author" content=""/>
+
+
+
+
+
+
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@washtimes" />
+<meta name="twitter:title" content="Police say 9-year-old boy had stolen car that hit house" />
+<meta name="twitter:description" content="Police have cited a 9-year-old boy who officers say stole a car, lost control of it and crashed into a Grand Island house." />
+
+
+
+  <meta property="og:title" content="Police say 9-year-old boy had stolen car that hit house"/>
+  <meta property="og:type" content="article"/>
+  <meta property="og:url" content="https://www.washingtontimes.com/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/"/>
+
+
+
+
+
+
+  <meta property="og:site_name" content="The Washington Times"/>
+  <meta property="og:description" content="Police have cited a 9-year-old boy who officers say stole a car, lost control of it and crashed into a Grand Island house."/>
+
+
+    <meta name="news_keywords" content="Law Crime"/>
+
+  <script type='text/javascript' data-cfasync='false' src='//dsms0mj1bbhn4.cloudfront.net/assets/pub/shareaholic.js'
+          data-shr-siteid='1b4cd6dea80b282c132df03b8b3fd9ac' async='async'></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "NewsArticle",
+    "mainEntityOfPage": "https://washingtontimes.com/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/",
+    "headline": "Police say 9-year-old boy had stolen car that hit house",
+
+
+    "datePublished": "2019-07-08T13:24:53",
+    "author": {
+      "@type": "Person",
+      "name": "Associated Press"
+    },
+     "publisher": {
+      "@type": "Organization",
+      "name": "The Washington Times",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://twt-assets.washtimes.com/v4/images/logo-black-text-600x60.png",
+        "width": 600,
+        "height": 60
+      }
+    },
+    "description": "Police have cited a 9-year-old boy who officers say stole a car, lost control of it and crashed into a Grand Island house."
+  }
+  </script>
+
+
+
+
+	<link rel="shortcut icon" href="//twt-assets.washtimes.com/images/favicon.30333d68dff6.ico" />
+	<link rel="apple-touch-icon" href="//twt-assets.washtimes.com/v4/images/icons/apple-touch-icon-precomposed.faa3cb2fc54e.png" />
+	<link rel="apple-touch-icon" sizes="72x72" href="//twt-assets.washtimes.com/v4/images/icons/apple-touch-icon-72x72-precomposed.a1d8974619ea.png" />
+	<link rel="apple-touch-icon" sizes="114x114" href="//twt-assets.washtimes.com/v4/images/icons/apple-touch-icon-114x114-precomposed.5ca7e79711fa.png" />
+	<link rel="apple-touch-icon" sizes="144x144" href="//twt-assets.washtimes.com/v4/images/icons/apple-touch-icon-precomposed.faa3cb2fc54e.png" />
+
+  <link rel="canonical" href="https://www.washingtontimes.com/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/" />
+
+
+	<link rel="stylesheet" href="//twt-assets.washtimes.com/css/global.cd59a7d6d830.css" />
+
+  <link href="//twt-assets.washtimes.com/sass/main.0b9f4d3dbbf0.css" rel="stylesheet" type="text/css" />
+	<link id="css-google-fonts" rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,400italic,700,700italic|Montserrat:400,700|Signika:400,600" media="all" />
+	<link id="css-font-awesome" rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" media="all" />
+
+
+  <link rel="stylesheet" type="text/css" href="//twt-assets.washtimes.com/css/tablet.d12a55c63ff0.css" media="(max-width: 1257px)" />
+
+	<!--[if IE]><link id="css-twig-ie" rel="stylesheet" type="text/css" href="//twt-assets.washtimes.com/v4/css/ie.6041df651bb7.css" media="all" /><![endif]-->
+	<!--[if lt IE 9]>
+		<script type="text/javascript" src="//cdn.jsdelivr.net/html5shiv/3.7.0/html5shiv.js"></script>
+		<script type="text/javascript" src="//twt-assets.washtimes.com/v4/js/respond.custom.min.f788fbb39f96.js"></script>
+	<![endif]-->
+
+
+<style type="text/css">
+@media all and (max-width: 500px) {
+  .jcarousel-wrapper {
+    display: none !important;
+  }
+}
+</style>
+
+
+
+  <!-- Facebook Pixel Code -->
+  <script>
+  !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+  n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+  document,'script','https://connect.facebook.net/en_US/fbevents.js');
+
+  fbq('init', '329974197684672');
+<!-- Facebook Engage Pixel -->
+  fbq('init', '450591302454597');
+<!-- End Facebook Engage Pixel -->
+
+  fbq('track', "PageView");
+  fbq('track', 'ViewContent');
+
+
+fbq('trackSingle', '450591302454597' , 'Subscribe', {value: '0.00', currency: 'USD', predicted_ltv: '0.00'});
+  </script>
+  <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=1061671217207746&ev=PageView&noscript=1" /></noscript>
+  <!-- End Facebook Pixel Code -->
+
+
+
+
+
+
+
+<!-- Facebook Link Ownership -->
+<meta property="fb:pages" content="35994014410" />
+<!-- END Facebook Link Ownership -->
+
+<!-- Google+ Experiment -->
+<link href="https://plus.google.com/u/0/112795231933243492488" rel="publisher" />
+<!-- END Google+ Experiment -->
+
+<!-- BEGIN Bing UET -->
+<script>(function(w,d,t,r,u){var f,n,i;w[u]=w[u]||[],f=function(){var o={ti:"5695066"};o.q=w[u],w[u]=new UET(o),w[u].push("pageLoad")},n=d.createElement(t),n.src=r,n.async=1,n.onload=n.onreadystatechange=function(){var s=this.readyState;s&&s!=="loaded"&&s!=="complete"||(f(),n.onload=n.onreadystatechange=null)},i=d.getElementsByTagName(t)[0],i.parentNode.insertBefore(n,i)})(window,document,"script","//bat.bing.com/bat.js","uetq");</script><noscript><img src="//bat.bing.com/action/0?ti=5695066&Ver=2" height="0" width="0" style="display:none; visibility: hidden;" /></noscript>
+<!-- END Bing UET -->
+
+<!-- Twitter universal website tag code -->
+<script>
+  !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+  },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js',
+  a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+  // Insert Twitter Pixel ID and Standard Event data below
+  twq('init','nwae8');
+  twq('track','PageView');
+</script>
+<!-- End Twitter universal website tag code -->
+
+<!-- LiveConnectTag for publishers -->
+<script type="text/javascript" src="//b-code.liadm.com/a-01en.min.js" async="true" charset="utf-8"></script>
+<!-- LiveConnectTag for publishers -->
+
+<noscript><div id="no-js-warning">JavaScript is required for full functionality on this website, but scripting is currently disabled. Please enable JavaScript and reload this page.</div></noscript>
+
+
+
+
+
+
+
+
+
+  <!-- BEGIN: Google Analytics -->
+  <script type="text/javascript">
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-3328123-2']);
+    _gaq.push(['_setCustomVar', 1, 'PageType', 'Story', ]);
+_gaq.push(['_setCustomVar', 4, 'UserSegment', 'Anonymous', ]);
+_gaq.push(['_setCustomVar', 3, 'ChildNode', 'national', ]);
+_gaq.push(['_setCustomVar', 2, 'TopNode', 'news', ]);
+_gaq.push(['_setCustomVar', 5, 'Author', 'Associated Press', ]);
+
+    _gaq.push(['_setCustomVar', 1, 'Segmentation', GPT.segmentation]);
+    _gaq.push(['_setDomainName', 'washingtontimes.com']);
+    _gaq.push(['_addIgnoredOrganic', 'washington times']);
+    _gaq.push(['_addIgnoredOrganic', 'the washington times']);
+    _gaq.push(['_addIgnoredOrganic', 'washingtontimes']);
+    _gaq.push(['_addIgnoredOrganic', 'washingtontimes.com']);
+    _gaq.push(['_addIgnoredOrganic', 'www.washingtontimes.com']);
+    _gaq.push(['_addIgnoredOrganic', 'washington times newspaper']);
+    _gaq.push(['_addIgnoredOrganic', 'washington times news']);
+    _gaq.push(['_addIgnoredOrganic', 'wash times']);
+    _gaq.push(['_addIgnoredOrganic', 'washtimes']);
+    _gaq.push(['_addIgnoredOrganic', 'washtimes.com']);
+    _gaq.push(['_addIgnoredOrganic', 'washington time']);
+    _gaq.push(['_addIgnoredOrganic', 'washington times.com']);
+    _gaq.push(['_addIgnoredOrganic', 'washinton times']);
+    _gaq.push(['_addIgnoredOrganic', 'wahington times']);
+    _gaq.push(['_addIgnoredOrganic', 'the washington times newspaper']);
+    _gaq.push(['_trackPageview']);
+    (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(ga);
+    })();
+
+    var sitepage;
+  </script>
+  <!-- END: Google Analytics -->
+
+
+
+
+
+
+  <script>
+    $(document).ready(function () {
+      $("#sponsored_block").click(function () {
+        $("#sponsored_content_block").slideToggle("slow", function () {
+          // Animation complete.
+        });
+      });
+    });
+  </script>
+
+  <style type="text/css">
+    .sponsored .page-headline,
+    .sponsored .storyareawrapper p {
+      font-family: georgia;
+    }
+
+    .bigtext {
+      display: block;
+      overflow: hidden;
+      color: #787878;
+    }
+
+    .expand, .contract {
+      cursor: pointer;
+      font-weight: bold;
+      padding: 15px 0;
+      text-align: center;
+      color: #b00021;
+      font-size: 20px;
+    }
+
+    .expand:hover, .contract:hover {
+      color: #555;
+    }
+
+    .hide {
+      display: none;
+    }
+  </style>
+
+  <link rel="stylesheet" type="text/css" href="//twt-assets.washtimes.com/css/story.a2dc352edd5f.css"/>
+
+
+
+
+  <script>
+  /*
+   from http://detectmobilebrowsers.com/
+   generated 2014-10-10
+   */
+
+  (function(w, n) {
+      'use strict';
+      w.adbladeExports = w.adbladeExports || {};
+      adbladeExports.isMobile = (function(a){
+          return /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0,4));
+      })(n.userAgent||n.vendor||w.opera);
+
+      adbladeExports.isTablet = !adbladeExports.isMobile && typeof w.orientation !== 'undefined';
+
+   })(window, navigator);
+
+</script>
+
+
+  <div id="fb-root"></div>
+  <script>(function (d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return;
+    js = d.createElement(s);
+    js.id = id;
+    js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.5";
+    fjs.parentNode.insertBefore(js, fjs);
+  }(document, 'script', 'facebook-jssdk'));</script>
+
+
+
+
+
+  <script>
+    function comscoreBeacon () {
+      (self.COMSCORE && COMSCORE.beacon({c1: "2", c2: "17692074"}));
+      $.get('/comscore-pageview-candidate.html');
+    }
+  </script>
+
+
+  <script type="text/javascript">
+    $(window).scroll(function() {
+      if ($(window).width() > 800) {
+        if ($(this).scrollTop() > 150) {
+          $('.header-container').addClass('sticky');
+          $('body').css('padding-top', '157px');
+          updateMenuAccountOptions(true);
+        } else {
+          $('.header-container').removeClass('sticky');
+          $('body').css('padding-top', 0);
+          updateMenuAccountOptions(false);
+        }
+      }
+    });
+
+    // Mobile menu
+    $(document).ready(function() {
+      var buttonCount = 0;
+      var slideMenu = document.querySelector('#cssmenu');
+
+      $('#mobileMenuButton').on('click', function() {
+        $(this).toggleClass('open');
+
+        if (buttonCount % 2 === 0) {
+          slideMenu.style.marginTop = 0;
+          buttonCount++;
+        } else {
+          slideMenu.style.marginTop = '-200vh';
+          buttonCount++;
+        }
+      });
+    });
+  </script>
+
+<!-- Engage Google re-marketing -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-771189196"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'AW-771189196');
+  </script>
+</head>
+
+<body class="
+
+
+    home with-editors-pick-info-bar
+
+
+">
+
+
+
+  <!-- Begin #wrapper -->
+  <div id="wrapper">
+
+
+
+
+<div style="display: none;"><div id="div-gpt-ad-oop">
+  <script type="text/javascript">
+
+    (function() {
+      function twig_qs() {
+        var result = {},
+        keyValuePairs = location.search.slice(1).split('&');
+        keyValuePairs.forEach(function(keyValuePair) {
+            keyValuePair = keyValuePair.split('=');
+            result[keyValuePair[0]] = keyValuePair[1] || '';
+        });
+        return result;
+      }
+      function getCookieValue(a) {
+        var b = document.cookie.match('(^|[^;]+)\\s*' + a + '\\s*=\\s*([^;]+)');
+        return b ? b.pop() : '';
+      }
+      //check for Chacka in full request path
+      var fromChacka = window.location.href.search(new RegExp('Chacka', 'i')) >= 0;
+
+      // check for 'mkt_tok' in params
+      var fromMarketo = twig_qs()['mkt_tok'];
+      var fromOneSignal = getCookieValue('RefererIsOneSignal');
+      var isPreferred = getCookieValue('Segmentation');
+      var isQuizPage = window.location.href.match(/\/quiz/);
+      var sessionPageViews = parseInt(getCookieValue('ads_spv'));
+
+      // don't ever show interstitial on quiz pages
+      if (!isQuizPage && !fromMarketo && !fromChacka && !fromOneSignal) {
+        if (isPreferred === 'Preferred' || sessionPageViews > 1) {
+          // out of page ad slot display
+          googletag.cmd.push(function () {
+            googletag.display('div-gpt-ad-oop');
+          });
+        }
+      }
+    })();
+    </script>
+</div></div>
+
+
+
+
+    <div class="sr-only"><a href="#content" title="Skip to content">Skip to content</a></div>
+
+    <div class="globalheader_container">
+
+      <div class="header-container">
+        <div id="mobileMenuButton">
+          <span></span><span></span><span></span><span></span>
+        </div>
+        <div class="wrapcontainer">
+          <header id="mainnav">
+            <div class="topper">
+              <div class="sponsor headcol"></div>
+              <div class="sitelogo headcol">
+                <a data-track-event="NavBar,home-logo,positionhome" href="/" title="The Washington Times | Home"><img
+                  src="//twt-assets.washtimes.com/images/TWTlogo3.5238e37e24b5.png" alt="Logo: The Washington Times"
+                  class="blacklogo"/><img src="//twt-assets.washtimes.com/img/WLogoNoBack.b80e1949f96a.png"
+                                          alt="Logo: The Washington Times" class="whitelogo"
+                                          style="display: none;"/></a><br/><em>Reliable Reporting. The Right
+                Opinion.</em>
+              </div>
+              <div class="signin headcol" style="vertical-align: middle">
+                <div class="signinbox">
+                  <div class="leftSignin">
+                    <a href="/subscribe/?subscribe-button-header">
+                      <strong>Subscribe</strong><br/>
+                    </a>
+                  </div>
+                  <div class="leftWelcome">
+                    <strong>Welcome</strong><br/>
+                  </div>
+
+
+
+                  <div class="rightSignin dropdownmenu">
+
+                    <p class="dropbtn" id="piano-login" style="margin:0px; min-width: 75px; font-size: 18px">
+                      <strong class="dropbtn">Sign In</strong>
+                    </p>
+
+                      <div id="anonUserMenu" style="display:none">
+                        <a href="javascript: showPianoLogin()">Sign In</a>
+                        <a href="https://washingtontimes-dc.newsmemory.com/?utm_source=washingtontimes&utm_medium=header">Today's E-Edition</a>
+                        <a href="/subscribe/?subscribe-button-header">Subscribe</a>
+                      </div>
+
+                       <div id="memberMenu" style="display:none">
+                        <a href="javascript: pianoLogout()">Sign Out</a>
+                        <a href="https://washingtontimes-dc.newsmemory.com/?utm_source=washingtontimes&utm_medium=header">Today's E-Edition</a>
+                        <a href="/my-account/">My Account</a>
+                        <a href="/subscribe/?subscribe-button-header">Subscribe</a>
+                      </div>
+
+                  </div>
+                </div>
+              </div>
+            </div>
+          </header>
+          <div id="cssmenu">
+            <ul>
+
+
+
+	<li class="has-sub active" id="nav_root_news">
+		<a id="main-nav-drop1" href="javascript:;" title="News">News</a>
+
+
+	<ul>
+
+		<li class="has-sub"><a href="/news/politics/" title="Politics" data-track-event="NavBarSub,politics,positionpolitics">Politics</a>
+		</li>
+
+		<li class="has-sub"><a href="/news/national/" title="National" data-track-event="NavBarSub,national,positionnational">National</a>
+		</li>
+
+		<li class="has-sub"><a href="/news/world/" title="World" data-track-event="NavBarSub,world,positionworld">World</a>
+		</li>
+
+		<li class="has-sub"><a href="/news/security/" title="Security" data-track-event="NavBarSub,security,positionsecurity">Security</a>
+		</li>
+
+		<li class="has-sub"><a href="/news/business-economy/" title="Business &amp; Economy" data-track-event="NavBarSub,business-economy,positionbusiness-economy">Business &amp; Economy</a>
+		</li>
+
+		<li class="has-sub"><a href="/news/local/" title="D.C. Local" data-track-event="NavBarSub,dc-local,positiondc-local">D.C. Local</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/faith-and-family/" title="Faith &amp; Family" data-track-event="NavBarSub,faith-family,positionfaith-family">Faith &amp; Family</a>
+		</li>
+
+		<li class="has-sub"><a href="/news/inside-politics/" title="Inside Politics" data-track-event="NavBarSub,inside-politics,positioninside-politics">Inside Politics</a>
+		</li>
+
+		<li class="has-sub"><a href="/news/inside-the-beltway/" title="Inside the Beltway" data-track-event="NavBarSub,inside-the-beltway,positioninside-the-beltway">Inside the Beltway</a>
+		</li>
+
+		<li class="has-sub"><a href="/news/inside-the-ring/" title="Inside the Ring" data-track-event="NavBarSub,inside-the-ring,positioninside-the-ring">Inside the Ring</a>
+		</li>
+
+		<li class="has-sub"><a href="/culture/" title="Culture" data-track-event="NavBarSub,culture,positionculture">Culture</a>
+		</li>
+
+		<li class="has-sub"><a href="/culture/entertainment/" title="Entertainment" data-track-event="NavBarSub,entertainment,positionentertainment">Entertainment</a>
+		</li>
+
+		<li class="has-sub"><a href="/culture/technology/" title="Technology" data-track-event="NavBarSub,technology,positiontechnology">Technology</a>
+		</li>
+
+		<li class="has-sub"><a href="http://www.legacy.com/washingtontimes/" title="Obituaries" data-track-event="NavBarSub,obituaries,positionobituaries">Obituaries</a>
+		</li>
+
+		<li class="has-sub"><a href="/news/today/" title="Just the Headlines" data-track-event="NavBarSub,just-the-headlines,positionjust-the-headlines">Just the Headlines</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/trump-central/" title="Trump Central" data-track-event="NavBarSub,trump-central,positiontrump-central">Trump Central</a>
+		</li>
+
+		<li class="has-sub"><a href="/multimedia/" title="Photo Galleries" data-track-event="NavBarSub,photo-galleries,positionphoto-galleries">Photo Galleries</a>
+		</li>
+
+	</ul>
+
+
+	</li>
+
+	<li class="has-sub" id="nav_root_policy">
+		<a id="main-nav-drop2" href="javascript:;" title="Policy">Policy</a>
+
+
+	<ul>
+
+		<li class="has-sub"><a href="/specials/energy-environment-news/" title="Energy &amp; Environment" data-track-event="NavBarSub,energy-environment,positionenergy-environment">Energy &amp; Environment</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/banking-finance/" title="Banking &amp; Finance" data-track-event="NavBarSub,banking-finance,positionbanking-finance">Banking &amp; Finance</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/health-care-reform/" title="Health Care Reform" data-track-event="NavBarSub,health-care-reform,positionhealth-care-reform">Health Care Reform</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/second-amendment-and-gun-control/" title="Second Amendment" data-track-event="NavBarSub,second-amendment,positionsecond-amendment">Second Amendment</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/immigration-reform/" title="Immigration Reform" data-track-event="NavBarSub,immigration-reform,positionimmigration-reform">Immigration Reform</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/intelligence-cybersecurity/" title="Homeland &amp; Cybersecurity" data-track-event="NavBarSub,homeland-cybersecurity,positionhomeland-cybersecurity">Homeland &amp; Cybersecurity</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/defense-aerospace/" title="Aerospace &amp; Defense" data-track-event="NavBarSub,aerospace-defense,positionaerospace-defense">Aerospace &amp; Defense</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/taxes-budget/" title="Taxes &amp; Budget" data-track-event="NavBarSub,taxes-budget,positiontaxes-budget">Taxes &amp; Budget</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/law-enforcement-intelligence/" title="Law Enforcement &amp; Intelligence" data-track-event="NavBarSub,law-enforcement-intelligence,positionlaw-enforcement-intelligence">Law Enforcement &amp; Intelligence</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/transportation-infrastructure/" title="Transportation &amp; Infrastructure" data-track-event="NavBarSub,transportation-infrastructure,positiontransportation-infrastructure">Transportation &amp; Infrastructure</a>
+		</li>
+
+	</ul>
+
+
+	</li>
+
+	<li class="has-sub" id="nav_root_investigations">
+		<a id="main-nav-drop3" href="javascript:;" title="Investigations">Investigations</a>
+
+
+	<ul>
+
+		<li class="has-sub"><a href="/news/waste-fraud-abuse/" title="Waste, Fraud &amp; Abuse" data-track-event="NavBarSub,waste-fraud-abuse,positionwaste-fraud-abuse">Waste, Fraud &amp; Abuse</a>
+		</li>
+
+		<li class="has-sub"><a href="/media-spotlight/" title="Media Spotlight" data-track-event="NavBarSub,media-spotlight,positionmedia-spotlight">Media Spotlight</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/dive-deeper/" title="Dive Deeper" data-track-event="NavBarSub,dive-deeper,positiondive-deeper">Dive Deeper</a>
+		</li>
+
+	</ul>
+
+
+	</li>
+
+	<li class="has-sub" id="nav_root_opinion">
+		<a id="main-nav-drop4" href="/opinion/" title="Opinion">Opinion</a>
+
+
+	<ul>
+
+		<li class="has-sub"><a href="/opinion/" title="Opinion Main" data-track-event="NavBarSub,opinion-main,positionopinion-main">Opinion Main</a>
+		</li>
+
+		<li class="has-sub"><a href="/opinion/commentary/" title="Commentary" data-track-event="NavBarSub,commentary,positioncommentary">Commentary</a>
+		</li>
+
+		<li class="has-sub"><a href="/opinion/editorials/" title="Editorials" data-track-event="NavBarSub,editorials,positioneditorials">Editorials</a>
+		</li>
+
+		<li class="has-sub"><a href="/opinion/letters/" title="Letters" data-track-event="NavBarSub,letters,positionletters">Letters</a>
+		</li>
+
+		<li class="has-sub"><a href="/opinion/pruden-on-politics/" title="Pruden on Politics" data-track-event="NavBarSub,pruden-on-politics,positionpruden-on-politics">Pruden on Politics</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/charles-hurt/" title="Charles Hurt" data-track-event="NavBarSub,charles-hurt,positioncharles-hurt">Charles Hurt</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/david-keene/" title="David Keene" data-track-event="NavBarSub,david-keene,positiondavid-keene">David Keene</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/tammy-bruce/" title="Tammy Bruce" data-track-event="NavBarSub,tammy-bruce,positiontammy-bruce">Tammy Bruce</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/ralph-z-hallow/" title="Ralph Z. Hallow" data-track-event="NavBarSub,ralph-z-hallow,positionralph-z-hallow">Ralph Z. Hallow</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/stephen-moore/" title="Stephen Moore" data-track-event="NavBarSub,stephen-moore,positionstephen-moore">Stephen Moore</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/cal-thomas/" title="Cal Thomas" data-track-event="NavBarSub,cal-thomas,positioncal-thomas">Cal Thomas</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/clifford-d-may/" title="Clifford D. May" data-track-event="NavBarSub,clifford-d-may,positionclifford-d-may">Clifford D. May</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/cheryl-k-chumley/" title="Cheryl K. Chumley" data-track-event="NavBarSub,cheryl-k-chumley,positioncheryl-k-chumley">Cheryl K. Chumley</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/joseph-curl/" title="Joseph Curl" data-track-event="NavBarSub,joseph-curl,positionjoseph-curl">Joseph Curl</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/everett-piper/" title="Everett Piper" data-track-event="NavBarSub,everett-piper,positioneverett-piper">Everett Piper</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/matt-mackowiak/" title="Matt Mackowiak" data-track-event="NavBarSub,matt-mackowiak,positionmatt-mackowiak">Matt Mackowiak</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/robert-knight/" title="Robert Knight" data-track-event="NavBarSub,robert-knight,positionrobert-knight">Robert Knight</a>
+		</li>
+
+		<li class="has-sub"><a href="/opinion/rapid-reactions/" title="Rapid Reactions" data-track-event="NavBarSub,rapid-reactions,positionrapid-reactions">Rapid Reactions</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/tim-constantine/" title="Tim Constantine" data-track-event="NavBarSub,tim-constantine,positiontim-constantine">Tim Constantine</a>
+		</li>
+
+		<li class="has-sub"><a href="/books/" title="Books" data-track-event="NavBarSub,books,positionbooks">Books</a>
+		</li>
+
+		<li class="has-sub"><a href="/cartoons/" title="Cartoons" data-track-event="NavBarSub,cartoons,positioncartoons">Cartoons</a>
+		</li>
+
+		<li class="has-sub"><a href="/news/threat-assessment/" title="Threat Assessment" data-track-event="NavBarSub,threat-assessment,positionthreat-assessment">Threat Assessment</a>
+		</li>
+
+		<li class="has-sub"><a href="/opinion/us-russia-crosstalk/" title="U.S.-Russia Crosstalk" data-track-event="NavBarSub,us-russia-crosstalk,positionus-russia-crosstalk">U.S.-Russia Crosstalk</a>
+		</li>
+
+	</ul>
+
+
+	</li>
+
+	<li class="has-sub" id="nav_root_sports">
+		<a id="main-nav-drop5" href="/sports/" title="Sports">Sports</a>
+
+
+	<ul>
+
+		<li class="has-sub"><a href="/sports/" title="Sports Main" data-track-event="NavBarSub,sports-main,positionsports-main">Sports Main</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/washington-redskins-season/" title="Redskins" data-track-event="NavBarSub,redskins,positionredskins">Redskins</a>
+		</li>
+
+		<li class="has-sub"><a href="/sports/football/" title="Football" data-track-event="NavBarSub,football,positionfootball">Football</a>
+		</li>
+
+		<li class="has-sub"><a href="/sports/baseball/" title="Baseball" data-track-event="NavBarSub,baseball,positionbaseball">Baseball</a>
+		</li>
+
+		<li class="has-sub"><a href="/sports/basketball/" title="Basketball" data-track-event="NavBarSub,basketball,positionbasketball">Basketball</a>
+		</li>
+
+		<li class="has-sub"><a href="/sports/ncaa/" title="NCAA" data-track-event="NavBarSub,ncaa,positionncaa">NCAA</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/thom-loverro/" title="Thom Loverro" data-track-event="NavBarSub,thom-loverro,positionthom-loverro">Thom Loverro</a>
+		</li>
+
+		<li class="has-sub"><a href="/staff/deron-snyder/" title="Deron Snyder" data-track-event="NavBarSub,deron-snyder,positionderon-snyder">Deron Snyder</a>
+		</li>
+
+		<li class="has-sub"><a href="/sports/tennis/" title="Tennis" data-track-event="NavBarSub,tennis,positiontennis">Tennis</a>
+		</li>
+
+		<li class="has-sub"><a href="/sports/golf/" title="Golf" data-track-event="NavBarSub,golf,positiongolf">Golf</a>
+		</li>
+
+		<li class="has-sub"><a href="/sports/hockey/" title="Hockey" data-track-event="NavBarSub,hockey,positionhockey">Hockey</a>
+		</li>
+
+		<li class="has-sub"><a href="/sports/soccer/" title="Soccer" data-track-event="NavBarSub,soccer,positionsoccer">Soccer</a>
+		</li>
+
+		<li class="has-sub"><a href="/sports/horse-racing/" title="Horse Racing" data-track-event="NavBarSub,horse-racing,positionhorse-racing">Horse Racing</a>
+		</li>
+
+		<li class="has-sub"><a href="/sports/racing/" title="NASCAR &amp; Racing" data-track-event="NavBarSub,nascar-racing,positionnascar-racing">NASCAR &amp; Racing</a>
+		</li>
+
+	</ul>
+
+
+	</li>
+
+	<li class="has-sub" id="nav_root_special_reports">
+		<a id="main-nav-drop6" href="/specials/" title="Special Reports">Special Reports</a>
+
+
+	<ul>
+
+		<li class="has-sub"><a href="/specials/" title="Special Reports Main" data-track-event="NavBarSub,special-reports-main,positionspecial-reports-main">Special Reports Main</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/americas-opioid-addiction/" title="America&#39;s Opioid Addiction" data-track-event="NavBarSub,americas-opioid-addiction,positionamericas-opioid-addiction">America&#39;s Opioid Addiction</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/agricultural-mixed-use-revolutionizing-farming/" title="Agricultural Mixed-Use" data-track-event="NavBarSub,agricultural-mixed-use,positionagricultural-mixed-use">Agricultural Mixed-Use</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/sonospine-spinal-fusion-avoidance/" title="SonoSpine®" data-track-event="NavBarSub,sonospine,positionsonospine">SonoSpine®</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/commerce-alliance-against-china/" title="Commerce Alliance Against China" data-track-event="NavBarSub,commerce-alliance-against-china,positioncommerce-alliance-against-china">Commerce Alliance Against China</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/greaterkarachi/" title="#GreaterKarachi" data-track-event="NavBarSub,greaterkarachi,positiongreaterkarachi">#GreaterKarachi</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/new-africa/" title="New Africa" data-track-event="NavBarSub,new-africa,positionnew-africa">New Africa</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/rolling-thunder-holds-32nd-ride/" title="Rolling Thunder XXXII" data-track-event="NavBarSub,rolling-thunder-xxxii,positionrolling-thunder-xxxii">Rolling Thunder XXXII</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/qatar-what-makes-americas-great-ally-special/" title="Qatar" data-track-event="NavBarSub,qatar,positionqatar">Qatar</a>
+		</li>
+
+		<li class="has-sub"><a href="/specials/free-iran-rally-2019-washington-dc/" title="Free Iran Rally 2019" data-track-event="NavBarSub,free-iran-rally-2019,positionfree-iran-rally-2019">Free Iran Rally 2019</a>
+		</li>
+
+	</ul>
+
+
+	</li>
+
+	<li class="has-sub" id="nav_root_games">
+		<a id="main-nav-drop7" href="/puzzles/games/" title="Games">Games</a>
+
+
+	<ul>
+
+		<li class="has-sub"><a href="/puzzles/games/" title="Games Main" data-track-event="NavBarSub,games-main,positiongames-main">Games Main</a>
+		</li>
+
+		<li class="has-sub"><a href="/puzzles/sudoku/" title="Play Sudoku" data-track-event="NavBarSub,play-sudoku,positionplay-sudoku">Play Sudoku</a>
+		</li>
+
+		<li class="has-sub"><a href="/puzzles/crossword/" title="Crossword Puzzle" data-track-event="NavBarSub,crossword-puzzle,positioncrossword-puzzle">Crossword Puzzle</a>
+		</li>
+
+		<li class="has-sub"><a href="/puzzles/word-search/" title="Word Search" data-track-event="NavBarSub,word-search,positionword-search">Word Search</a>
+		</li>
+
+		<li class="has-sub"><a href="/quiz/" title="Quizzes" data-track-event="NavBarSub,quizzes,positionquizzes">Quizzes</a>
+		</li>
+
+	</ul>
+
+
+	</li>
+
+	<li class="has-sub" id="nav_root_subscribe">
+		<a id="main-nav-drop8" href="/subscribe/?subscribe-button-scroll" title="Subscribe">Subscribe</a>
+
+
+
+	</li>
+
+	<li class="has-sub" id="nav_root_signin">
+		<a id="main-nav-drop9" href="/piano-sign-in" title="Sign In">Sign In</a>
+
+
+
+	</li>
+
+
+
+            </ul>
+          </div>
+        </div>
+
+
+
+
+
+
+
+
+
+
+          <div class="topics">
+            <div class="topics">
+
+
+
+  <div><strong>TRENDING:</strong></div>
+
+    <div class="noborder"><a href="/topics/donald-trump/" title="Donald Trump" data-track-event="Hilighted,topics">Donald Trump</a></div>
+
+    <div><a href="/topics/walmart/" title="Walmart" data-track-event="Hilighted,topics">Walmart</a></div>
+
+    <div><a href="/topics/china/" title="China" data-track-event="Hilighted,topics">China</a></div>
+
+    <div><a href="/topics/national-football-league/" title="NFL" data-track-event="Hilighted,topics">NFL</a></div>
+
+    <div><a href="/topics/dayton/" title="Dayton" data-track-event="Hilighted,topics">Dayton</a></div>
+
+    <div><a href="/topics/washington/" title="Washington" data-track-event="Hilighted,topics">Washington</a></div>
+
+    <div><a href="/topics/usdcny/" title="Usd/Cny" data-track-event="Hilighted,topics">Usd/Cny</a></div>
+
+    <div><a href="/topics/nba/" title="Nba" data-track-event="Hilighted,topics">Nba</a></div>
+
+    <div><a href="/topics/united-nations/" title="United Nations" data-track-event="Hilighted,topics">United Nations</a></div>
+
+    <div><a href="/topics/connor-betts/" title="Connor Betts" data-track-event="Hilighted,topics">Connor Betts</a></div>
+
+
+
+            </div>
+          </div>
+
+      </div>
+
+    </div>
+
+    <!-- Begin Piano My-Account Section -->
+
+    <script>
+
+      function navIsSticky() {
+        if ($('.header-container.sticky').length ){
+          return true;
+        }
+        return false;
+      }
+
+      function updateMenuAccountOptions(isSticky) {
+        if (isSticky) {
+          tp = window.tp || [];
+          if (tp.pianoId) {
+            if (tp.pianoId.isUserValid()) {
+              $('#nav_root_subscribe').css('display', 'none');
+              $('#nav_root_signin a').text(tp.pianoId.getUser().given_name);
+              $('#nav_root_signin').css('display', 'inline-block').css('margin-left', '10px');
+            } else {
+              $('#nav_root_subscribe').css('display', 'inline-block');
+              $('#nav_root_signin a').text('Sign In');
+              $('#nav_root_signin').css('display', 'inline-block').css('margin-left', '-20px');
+            }
+          }
+
+        } else {
+          $('#nav_root_subscribe').css('display', 'none');
+          $('#nav_root_signin').css('display', 'none');
+
+        }
+      }
+
+      function showPianoLogin() {
+        tp = window.tp || [];
+        tp.push(["init", function () {
+          tp.pianoId.show({
+            screen: 'login',
+            loggedIn: function (data) {
+              console.log('user ', data.user, ' logged in with token', data.token);
+
+              //hide Subscribe button
+              $('#piano-login').html('<span class="signintext">' + tp.pianoId.getUser().given_name + '</span>');
+              $('.leftSignin').hide();
+              $('.leftWelcome').css('display', 'table-cell');
+
+              $('#anonUserMenu').removeClass('dropdown-content').css('display', 'none');
+              $('#memberMenu').addClass('dropdown-content').removeAttr('style');
+
+
+              $('.rightSignin').removeClass('rightSignin').addClass('accountButton');
+
+              $('#nav_root_subscribe').css('display', 'none');
+              $('#nav_root_signin a').text(tp.pianoId.getUser().given_name);
+              $('#nav_root_signin').css('display', 'inline-block').css('margin-left', '10px');
+
+              gtag('event', 'page_view', {'send_to': 'AW-771189196', 'user_id': data.user.uid});
+
+            }
+          });
+          $('.tp-modal').css('z-index', '2000000000');
+        }]);
+      }
+
+      function pianoLogout() {
+        console.log('logout');
+        tp = window.tp || [];
+        tp.pianoId.logout(function () {
+          $('#memberMenu').css('display', 'none');
+
+          $('#anonUserMenu').addClass('dropdown-content').removeAttr('style');
+          $('#memberMenu').removeClass('dropdown-content').css('display', 'none');
+
+          $('#piano-login').html('<strong>Sign In</strong>');
+          $('.leftSignin').show();
+          $('.leftWelcome').hide();
+          $('.accountButton').removeClass('accountButton').addClass('rightSignin');
+        });
+
+      }
+      //set initial user account state
+      tp = window.tp || [];
+      tp.push(["init", function() {
+
+        if (tp.pianoId.isUserValid()) {
+          $('#piano-login').html('<span class="signintext">' + tp.pianoId.getUser().given_name + '</span>');
+          //hide Subscribe button
+          $('.leftSignin').hide();
+          $('.leftWelcome').css('display', 'table-cell');
+          $('.rightSignin').removeClass('rightSignin').addClass('accountButton');
+
+          $('#anonUserMenu').removeClass('dropdown-content').css('display', 'none');
+          $('#memberMenu').addClass('dropdown-content').removeAttr('style');
+
+          gtag('event', 'page_view', { 'send_to': 'AW-771189196', 'user_id': tp.pianoId.getUser().uid });
+        } else {
+          $('#anonUserMenu').addClass('dropdown-content').removeAttr('style');
+          $('#memberMenu').removeClass('dropdown-content').css('display', 'none');
+        }
+
+      }]);
+
+      $(document).ready(function(){
+
+        //$('.rightSignin').hover(showMenu);
+
+        $('#nav_root_signin').click(function(evt){
+              evt.preventDefault();
+              showPianoLogin();
+        });
+
+      });
+
+    </script>
+
+    <!-- End Piano My-Account Section -->
+
+  </div>
+  <!-- End #wrapper -->
+
+
+    <div class="container">
+      <div id="ad-lead" data-size="970x90" class="ad">
+
+          <div class="ad-slot"
+     id="div-gpt-ad-leaderboard"
+     data-ad-settings="desktopLeaderboard">
+<script>
+  console.log('__ADS element on page', 'div-gpt-ad-leaderboard');
+  ADSFORPAGE.push('div-gpt-ad-leaderboard');
+</script>
+</div>
+
+
+
+      </div>
+    </div>
+
+
+
+  <!-- START 3-column layout -->
+  <div id="main" class="container">
+
+    <div class="right-border">
+
+        <nav id="breadcrumb" role="navigation">
+          <ul class="menu">
+            <li><a href="/">Home</a></li>
+
+              <li><a
+                href="/news/">News</a>
+              </li>
+              <li class="current"><a
+                href="/news/national/">National</a></li>
+
+          </ul>
+        </nav>
+
+
+      <div id="page-title-container">
+
+
+
+        <h1 class="page-headline">
+          Police say 9-year-old boy had stolen car that hit house</h1>
+
+
+      </div>
+    </div>
+
+    <div class="row equal-heights three-column with-sidebar with-sidebar-primary with-sidebar-secondary">
+
+
+<aside id="secondary" class="hidden-xs col-md-10 col-lg-8">
+  <div class="equal-heights-column-inner">
+    <div class="aside-inner">
+
+
+
+<div class="socialbar">
+  Follow Us
+
+  <a href="https://www.facebook.com/TheWashingtonTimes" target="_blank"><img src="//twt-assets.washtimes.com/img/icon-facebook.jpg" class="socialicon" /></a>
+  <a href="https://twitter.com/WashTimes" target="_blank"><img src="//twt-assets.washtimes.com/img/icon-twitter.jpg" class="socialicon" /></a>
+  <a href="https://www.instagram.com/washtimes/" target="_blank"><img src="//twt-assets.washtimes.com/img/icon-instagram.jpg" class="socialicon" /></a>
+  <a href="/feeds/"><img src="//twt-assets.washtimes.com/img/icon-rss.jpg" class="socialicon" /></a>
+
+</div>
+
+<div class="search">
+  <form id="frm_search" action="/search/">
+    <fieldset>
+      <legend class="sr-only">Search</legend>
+      <label for="search-keyword" class="sr-only" title="Search Keyword">Search Keyword:</label>
+      <input type="hidden" name="cx" value="015385541671335030271:nfb7f1nj88q" />
+      <input type="hidden" name="cof" value="FORID:11" />
+      <input type="hidden" name="ie" value="UTF-8" />
+      <input id="search-keyword" name="q" placeholder="Search" type="search" value="" />
+      <input type="submit" name="sa" value="GO" class="btn btn-default btn-xs" title="Search" />
+    </fieldset>
+  </form>
+  <script type="text/javascript" src="//www.google.com/coop/cse/brand?form=cse-search-box&lang=en"></script>
+</div>
+
+
+      <section class="block email-alerts">
+  <h2 class="block-title">Sign Up For
+    <small>Breaking News Alerts</small>
+  </h2>
+  <div class="block-content">
+    <div id="breaking-signup-block" style="color: #fff;">
+      <form action="/newsletters/boomtrain/subscribe/" method="POST" name="breakingSignupForm"
+            class="form-inline" onsubmit="emailAlertNewsletter(); return false;">
+        <fieldset>
+          <legend class="sr-only">Breaking News Alerts</legend>
+          <label for="alerts-email" class="sr-only" title="Enter your email address">Enter your email address:</label>
+          <input id="alerts-email" maxlength="40" name="email" placeholder="enter address&hellip;" type="Email"
+                 style="color: #000;"/>
+          <input value="Submit" title="Submit" type="submit"/>
+          <input type="hidden" value="on" name="breaking_news"/>
+
+        </fieldset>
+      </form>
+    </div>
+  </div>
+</section>
+<script>
+  function emailAlertNewsletter() {
+    let $form = $('form[name=breakingSignupForm]');
+    $.post($form.get(0).action, $form.serialize(), function (data) {
+      if (data.success) {
+        var formBlock = document.getElementById('breaking-signup-block');
+        var theForm = formBlock.getElementsByTagName('form')[0];
+        theForm.innerHTML = 'Your email <b>' + data.email + '</b> will receive this newsletter.';
+      }
+    });
+  }
+</script>
+<!-- //.email-alerts -->
+
+
+
+      <div id="ad-secondary-sidebar-1" data-size="300x600" class="ad hidden-xs">
+        <div class="ad-slot"
+     id="div-gpt-ad-right-sidebar-top"
+     data-ad-settings="desktopRightSideTop">
+<script>
+  console.log('__ADS element on page', 'div-gpt-ad-right-sidebar-top');
+  ADSFORPAGE.push('div-gpt-ad-right-sidebar-top');
+</script>
+</div>
+
+
+      </div>
+
+
+
+
+
+
+      <section class="block topic-list most-shared">
+        <h2 class="block-title">Recommended</h2>
+      <!--  6th August 2019 05:46-->
+        <div class="block-content">
+
+
+
+
+<article>
+	<div class="main-photo">
+			<a href="/quiz/2019/jun/13/guess-1970s-movie-famous-quote/" data-track-event="RecommendedBlock,RecommendedBlock,position1"><img src="https://twt-thumbs.washtimes.com/media/image/2019/06/13/1970sMovieQuotes-900_c188-0-712-524_s85x85.jpg?b0254c8db5ed38f9c35532203153253ce3304a2e" width="85" height="85" alt="obj.0.content_object.caption" /></a>
+	</div>
+	<h3 class="article-headline">
+		<a href="/quiz/2019/jun/13/guess-1970s-movie-famous-quote/" title="Can you guess the 1970s movie from its famous quote?" onclick="_gaq.push(['_trackEvent', 'RecommendedBlock', 'RecommendedBlock', 'position1']);">Quiz: Can you guess the 1970s movie from its famous quote?</a>
+	</h3>
+</article>
+
+
+
+
+<article>
+	<div class="main-photo">
+
+
+
+
+			<a href="/news/2019/jul/31/donald-trump-opens-door-drug-imports-canada/" data-track-event="RecommendedBlock,RecommendedBlock,position2"><img src="https://twt-thumbs.washtimes.com/media/image/2019/07/31/trump_prescription_drug_imports_83213_c415-0-2879-2464_s85x85.jpg?8d4c3fa155b6e3c0485798a5e9a3623d0de16a4c" width="85" height="85" alt="In this Wednesday, July 10, 2019, file photo, President Donald Trump speaks about kidney health, accompanied by Health and Human Services Secretary Alex Azar, left, in Washington. Azar says he and Trump are working on a plan to allow Americans to import lower-priced prescription drugs from Canada. (AP Photo/Alex Brandon, File)" /></a>
+
+	</div>
+	<h3 class="article-headline">
+		<a href="/news/2019/jul/31/donald-trump-opens-door-drug-imports-canada/" title="Trump reverses policy of importing drugs in bid to lower prices" onclick="_gaq.push(['_trackEvent', 'RecommendedBlock', 'RecommendedBlock', 'position2']);">Trump reverses policy of importing drugs in bid to lower prices</a>
+	</h3>
+</article>
+
+
+
+
+<article>
+	<div class="main-photo">
+			<a href="/quiz/2019/jun/20/can-name-tv-show-its-popular-song/" data-track-event="RecommendedBlock,RecommendedBlock,position3"><img src="https://twt-thumbs.washtimes.com/media/image/2019/06/20/TVshowThemeHits-900_c188-0-712-524_s85x85.jpg?b0254c8db5ed38f9c35532203153253ce3304a2e" width="85" height="85" alt="obj.0.content_object.caption" /></a>
+	</div>
+	<h3 class="article-headline">
+		<a href="/quiz/2019/jun/20/can-name-tv-show-its-popular-song/" title="Can you name the TV show from its popular theme song?" onclick="_gaq.push(['_trackEvent', 'RecommendedBlock', 'RecommendedBlock', 'position3']);">Quiz: Can you name the TV show from its popular theme song?</a>
+	</h3>
+</article>
+
+
+
+
+<article>
+	<div class="main-photo">
+
+
+
+
+			<a href="/news/2019/jul/31/boris-johnson-brexit-push-puts-us-trade-deal-fate-/" data-track-event="RecommendedBlock,RecommendedBlock,position4"><img src="https://twt-thumbs.washtimes.com/media/image/2019/07/31/Britain_Politics_23_c659-0-3059-2400_s85x85.jpg?98c3a4b4b2cb548caa7bb935ba29d79000776ca3" width="85" height="85" alt="Britain&amp;#39;s Prime Minister Boris Johnson gestures during a speech on domestic priorities at the Science and Industry Museum in Manchester, England, Saturday July 27, 2019. Economists have warned that leaving the European bloc without an agreement in under 100-days would disrupt trade to impact on finances and investment. (AP Photo/Rui Vieira)" /></a>
+
+	</div>
+	<h3 class="article-headline">
+		<a href="/news/2019/jul/31/boris-johnson-brexit-push-puts-us-trade-deal-fate-/" title="&#8216;Uncertainty&#8217;: Boris Johnson&#8217;s drive to Brexit puts fate of U.S. trade deal in question" onclick="_gaq.push(['_trackEvent', 'RecommendedBlock', 'RecommendedBlock', 'position4']);">&#8216;Uncertainty&#8217;: Boris Johnson&#8217;s drive to Brexit puts fate of U.S. trade deal in question</a>
+	</h3>
+</article>
+
+
+
+<article >
+	<div class="main-photo">
+		<a href="/multimedia/collection/best-concealed-carry-handgun-states-ranked/" data-track-event="RecommendedBlock,RecommendedBlock,position5">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2014/08/25/ap99040802570_c9-0-1219-1210_s85x85.jpg?d8e5c983eb16129d3b256d6edad2e3a091e8a474" width="85" height="85" alt="AP99040802570.jpg" />
+
+		</a>
+	</div>
+	<h3 class="article-headline">
+		<a href="/multimedia/collection/best-concealed-carry-handgun-states-ranked/" title="Best states for concealed carry — ranked worst to first" onclick="_gaq.push(['_trackEvent', 'RecommendedBlock', 'RecommendedBlock', 'position5']);">Best states for concealed carry — ranked worst to first</a>
+	</h3>
+</article>
+
+
+
+
+        </div>
+      </section>
+      <!-- //.ed-columns -->
+
+      <div id="ad-primary-story-flex" data-size="300x250" class="ad hidden-xs">
+        <div class="ad-slot"
+     id="div-gpt-ad-story-flex"
+     data-ad-settings="desktopStoryFlex">
+<script>
+  console.log('__ADS element on page', 'div-gpt-ad-story-flex');
+  ADSFORPAGE.push('div-gpt-ad-story-flex');
+</script>
+</div>
+
+
+      </div>
+
+
+
+        <section class="block breaking-news no-bottom-border">
+          <div class="block-content" style="border-top: 1px solid #ccc; border-bottom: 1px solid #ccc; padding: 10px 0;">
+
+              <article class="sponsored-container">
+<span class="sponsored-heading">SPONSORED CONTENT</span>
+<div class="sponsored-background">
+  <div class="main-photo">
+    <a href="http://gundrymd.com/cmd.php?ad=814771" target="_blank" onclick="_gaq.push(['_trackEvent', 'YMALpageAds', 'homepage-ad-tracking2', 'homepage-ad-tracking2']);"><img src="https://twt-media.washtimes.com/media/image/2016/08/17/Gundry-85.jpg" width="85" height="85" alt="How To: Fix Your Fatigue And Get More Energy"></a>
+  </div>
+  <h2 class="article-headline"><a href="http://gundrymd.com/cmd.php?ad=814771" target="_blank" onclick="_gaq.push(['_trackEvent', 'YMALpageAds', 'homepage-ad-tracking2', 'homepage-ad-tracking2']);" title="How To: Fix Your Fatigue And Get More Energy">How To: Fix Your Fatigue And Get More Energy</a></h2>
+  <div style="clear:both;"></div>
+</div>
+</article>
+
+          </div>
+        </section>
+
+
+      <div id="ad-primary-story-2" data-size="300x250" class="ad hidden-xs">
+        <div class="ad-slot"
+     id="div-gpt-ad-story-two"
+     data-ad-settings="desktopStoryTwo">
+<script>
+  console.log('__ADS element on page', 'div-gpt-ad-story-two');
+  ADSFORPAGE.push('div-gpt-ad-story-two');
+</script>
+</div>
+
+
+      </div>
+
+
+
+        <section class="block breaking-news no-bottom-border">
+          <div class="block-content" style="border-top: 1px solid #ccc; border-bottom: 1px solid #ccc; padding: 10px 0;">
+
+              <div id="L6Wh6EinvOZMP2dyoJbbAZuYVrZdC69gbJAHMH6l"></div>
+
+          </div>
+        </section>
+
+
+
+
+
+<section class="block our-voices desktop-only" style="border-bottom: 0 !important;">
+  <h2 class="block-title">Commentary</h2>
+  <div class="block-content">
+
+
+
+		<article >
+			<div class="main-photo">
+
+
+						<a href=""><img src="https://twt-thumbs.washtimes.com/media/img/staff/2015/cal-thomas-350_s85x119.jpg?aa9e42ea593811e08acc2f2e2737164ab5d201f0" width="85" height="119" alt="staff" /></a></a>
+
+
+			</div>
+	        <h3 class="article-headline" style="color: #000;"><a href=""><a href="/staff/cal-thomas/">Cal Thomas</a></a></h3>
+			<p><a href="/news/2019/aug/5/fixing-baltimore-plan/" title="Fixing Baltimore: A plan">Fixing Baltimore: A plan</a></p>
+
+		</article>
+
+
+
+		<article >
+			<div class="main-photo">
+
+
+						<a href=""><img src="https://twt-thumbs.washtimes.com/media/img/staff/2016/richard-rahn-350_s85x119.jpg?aa9e42ea593811e08acc2f2e2737164ab5d201f0" width="85" height="119" alt="staff" /></a></a>
+
+
+			</div>
+	        <h3 class="article-headline" style="color: #000;"><a href=""><a href="/staff/richard-w-rahn/">Richard W. Rahn</a></a></h3>
+			<p><a href="/news/2019/aug/5/stage-ii-and-beyond/" title="&#8216;Stage II and beyond&#8217;">&#8216;Stage II and beyond&#8217;</a></p>
+
+		</article>
+
+
+
+		<article style="border-bottom: 0;">
+			<div class="main-photo">
+
+
+						<a href=""><img src="https://twt-thumbs.washtimes.com/media/img/staff/2017/cheryl-chumley-350_s85x119.jpg?aa9e42ea593811e08acc2f2e2737164ab5d201f0" width="85" height="119" alt="staff" /></a></a>
+
+
+			</div>
+	        <h3 class="article-headline" style="color: #000;"><a href=""><a href="/staff/cheryl-k-chumley/">Cheryl K. Chumley</a></a></h3>
+			<p><a href="/news/2019/aug/6/why-shooters-shoot/" title="Why shooters shoot">Why shooters shoot</a></p>
+
+		</article>
+
+
+    <span class="view-all" style="float: right;"><a href="/opinion/" title="View all" data-track-event="CommentaryBlock,CommentaryBlock,position" style="color: #000; font-weight: bold; padding-bottom: 7px;">View all <i class="fa fa-arrow-circle-o-right"></i></a></span>
+  </div>
+</section>
+
+<!-- //.our-voices -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+      <div id="ad-primary-story-3" data-size="300x250" class="ad hidden-xs">
+        <div class="ad-slot"
+     id="div-gpt-ad-story-three"
+     data-ad-settings="desktopStoryThree">
+<script>
+  console.log('__ADS element on page', 'div-gpt-ad-story-three');
+  ADSFORPAGE.push('div-gpt-ad-story-three');
+</script>
+</div>
+
+
+      </div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<section class="block qotd">
+<h2 class="block-title">Question of the Day</h2>
+<div class="block-content">
+
+
+      <h3>Was President Trump wrong to criticize Baltimore?</h3>
+        <fieldset>
+          <legend class="sr-only">Question of the Day</legend>
+
+            <form action="/polls/2019/jul/29/was-president-trump-wrong-criticize-baltimore/" method="POST">
+    <!--  This is bot detection stuff, do not remove  -->
+    <input type='text' name='email' class='poll_required' value='valid_email'/>
+    <input type='text' name='username' class='poll_required'/>
+
+
+    <div class="field">
+        <input id="choice1" type="radio" name="choice" value="6387" />&nbsp;
+        <label for="choice1">Yes</label>
+    </div>
+
+    <div class="field">
+        <input id="choice2" type="radio" name="choice" value="6388" />&nbsp;
+        <label for="choice2">No</label>
+    </div>
+
+    <div class="field">
+        <input id="choice3" type="radio" name="choice" value="6389" />&nbsp;
+        <label for="choice3">Not sure</label>
+    </div>
+
+    <br />
+
+        <input type="submit" value="Vote" title="Vote" />
+
+    &nbsp; <a href="/polls/2019/jul/29/was-president-trump-wrong-criticize-baltimore/results/" class="ml small">View results</a></p>
+</form>
+
+
+        </fieldset>
+
+
+</div>
+</section>
+
+<!-- //.qotd -->
+
+
+      <div id="ad-primary-story-4" data-size="300x250" class="ad hidden-xs">
+        <div class="ad-slot"
+     id="div-gpt-ad-story-four"
+     data-ad-settings="desktopStoryFour">
+<script>
+  console.log('__ADS element on page', 'div-gpt-ad-story-four');
+  ADSFORPAGE.push('div-gpt-ad-story-four');
+</script>
+</div>
+
+
+      </div>
+
+
+
+
+
+
+
+		<section class="block whats-trending">
+		    <h2 class="block-title">Story TOpics</h2>
+		    <div class="block-content">
+		        <ul>
+
+
+		            <li><a href="/topics/law_crime/" title="" data-track-event="Hilighted,topics">Law_Crime</a></li>
+
+
+		        </ul>
+		    </div>
+		</section>
+		<!-- //.whats-trending -->
+
+
+
+
+
+    </div>
+
+</aside>
+<!-- //#secondary -->
+
+
+
+
+  <section id="content" class="col-xs-31 col-lg-22 right-border">
+    <div class="equal-heights-column-inner" style="padding-right: 15px; border-right: 1px solid #ccc;">
+      <div class="content-inner">
+        <!-- //#ad-lead-mobile -->
+        <section class="full-article">
+          <article style="margin-bottom: 0;">
+
+
+
+
+
+
+
+
+
+            <script type="text/javascript">
+              var _informq = _informq || [];
+              _informq.push(['hook', 'Inform-Washington-Times-Player-1/videoLoad', function (event) {
+              }]);
+            </script>
+
+
+
+
+
+
+
+
+            <div class="article-text">
+
+              <div class="share-and-comments">
+                <div class='shareaholic-canvas' data-app='share_buttons' data-app-id='24605281'></div>
+                <a class="expand-comments" href="javascript:window.print();"
+                   style="background: #555; padding: 10px; color: #fff; float: right; margin-top: 16px;"><i
+                  class="fa fa-print" aria-hidden="true"></i> Print</a>
+              </div>
+
+
+
+                <div class="meta" style="padding-top: 10px;">
+
+                    <span class="byline"> By  </span>
+                    <span class="source"> -
+
+				Associated Press
+ -
+
+
+                        Monday, July 8, 2019
+
+                    </span>
+
+                </div>
+
+
+
+
+              <div class="summary" id="font-resizer">
+
+
+
+
+
+                  <div class="storyareawrapper">
+
+                  <div class="bigtext">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                      <p>GRAND ISLAND, Neb. (AP) - Police have cited a 9-year-old boy who officers say stole a car, lost control of it and crashed into a Grand Island house.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+                      <p>A neighbor of the boy reported the car stolen Sunday night. Police spotted it but didn&#8217;t start a chase. It went out of control and ran through several yards before hitting the house.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+                      <p>Police say the boy wasn&#8217;t hurt and refused to get out of the car. Officers who broke in and took him out say he spit on them and used racial slurs. Police also say the boy had a knife on him.</p>
+
+
+
+                        <div class="read-more-show hide">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                        </div>
+
+
+
+
+
+
+
+
+
+                        <a name="pagebreak"></a>
+
+
+
+
+                      <p>He was cited for flight to avoid arrest, theft and other crimes.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                  <div id="newsletter-form-story">
+
+                      <div class="block-content" id="news-signup-block" style="margin-bottom: 20px;">
+                        <h3 class="block-title">Sign up for Daily Newsletters</h3>
+                        <form action="/newsletters/boomtrain/subscribe/" method="post" name="newsSignupForm" class="form-inline" onsubmit="newsNewsletter(); return false;" style="margin: 0; background: #e7e7e7; padding: 10px; margin-top: -16px;">
+                          <fieldset style="background: #e7e7e7; padding: 10px;">
+                            <input type="text" name="email" class="Email" placeholder="Email Address" style="font-size: 21px;"/>
+                            <input type="submit" value="Submit" style="font-size: 22px; border: 0; color: #fff; background: #a9091f; border-radius: 10px;"/>
+                            <input type="hidden" value="on" name="newsletter_morning"/>
+                            <input type="hidden" value="on" name="newsletter_evening"/>
+                          </fieldset>
+                        </form>
+                      </div>
+                      <script>
+                        function newsNewsletter() {
+                          let $form = $('form[name=newsSignupForm]');
+                          $.post($form.get(0).action, $form.serialize(), function (data) {
+                            if (data.success) {
+                              var formBlock = document.getElementById('news-signup-block');
+                              var theForm = formBlock.getElementsByTagName('form')[0];
+                              theForm.innerHTML = 'Your email <b>' + data.email + '</b> will receive this newsletter.';
+                            }
+                          });
+                        }
+                      </script>
+
+                 </div>
+                    <div class="permission">
+                      <p>Copyright &copy; 2019 The Washington Times, LLC. </p>
+                    </div>
+
+
+
+                        <div style="color: black; border: 1px solid gray; padding: 5px 15px 15px 15px; background-color: lightgrey"><h4>The Washington Times Comment Policy</h4>The Washington Times welcomes your comments on Spot.im, our third-party provider. Please read our <a href="https://www.washingtontimes.com/comment-policy/">Comment Policy</a> before commenting.</div>
+<div data-spotim-module="recirculation" data-spot-id="sp_iyCBIB1C"></div>
+<script src="https://recirculation.spot.im/spot/sp_iyCBIB1C"></script>
+<script async src="https://launcher.spot.im/spot/sp_iyCBIB1C"
+    data-spotim-module="spotim-launcher"
+    data-post-id="story_2229986"
+    data-post-url="https://www.washingtontimes.com/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/"
+    data-disqus-url="http://washingtontimes.com/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/"
+    data-disqus-identifier="story_2229986"
+    data-messages-count="2">
+</script>
+
+
+
+
+                  </div>
+
+                  <p>&nbsp;</p>
+
+
+
+
+
+
+
+
+
+                </div>
+
+                <p class="expand"
+                   onclick="_gaq.push(['_trackPageview', '/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/']); comscoreBeacon();"
+                   data-track-event="StoryMore,read_more,read_more"><i class="fa fa-arrow-down"></i> Click to Read More
+                  and View Comments <i class="fa fa-arrow-down"></i></p>
+                <p class="contract hide" onclick="_gaq.push(['_trackPageview', '/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/'])"
+                   data-track-event="StoryMore,read_less,read_less"><i class="fa fa-arrow-up"></i> Click to Hide <i
+                  class="fa fa-arrow-up"></i></p>
+
+
+                <div class="OUTBRAIN" data-src="DROP_PERMALINK_HERE" data-widget-id="AR_10"
+                     data-ob-template="TheWashingtonTimes"></div>
+                <script type="text/javascript" async="async" src="https://widgets.outbrain.com/outbrain.js"></script>
+
+              </div>
+
+            </div>
+
+          </article>
+
+
+            <section
+              class="block breaking-news no-bottom-border">
+              <h2 class="block-title">Top Stories</h2>
+              <div class="block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2018/12/02/AP_17159524305562_c855-0-4424-3569_s85x85.jpg?a937ce29c41e714547b2ed51d1c3448aafc0cccf" width="85" height="85" alt="Former FBI Director James Comey is sworn in during a Senate Intelligence Committee hearing on Capitol Hill, Thursday, June 8, 2017, in Washington. (AP Photo/Alex Brandon) ** FILE **" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/31/comey-lost-track-trump-memos-fbi-evidence-log-says/" title="FBI evidence log says Comey lost track of Trump memos" data-track-event="TopStoriesBlock,TopStoriesBlock,position1" style="color: #000000;">FBI evidence log says Comey lost track of Trump memos</a>
+	</h3>
+</article>
+
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2019/07/31/AP_19052713953264_c786-0-4374-3588_s85x85.jpg?54f5b1780536b31bfd69160576f469ad565ec94e" width="85" height="85" alt="In this Nov. 6, 2018, file photo, voters cast their ballots at the Denver Elections Division in Denver. (AP Photo/David Zalubowski, File)" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/31/colorado-national-popular-vote-foes-aim-2020-repea/" title="Colorado activists seek to beat hasty retreat from National Popular Vote compact" data-track-event="TopStoriesBlock,TopStoriesBlock,position2" style="color: #000000;">Colorado activists seek to beat hasty retreat from National Popular Vote compact</a>
+	</h3>
+</article>
+
+
+
+
+
+<!-- templates/positions/render/ymal/quiz_quiz.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+			<a href="/quiz/2015/feb/11/us-citizenship-test-could-you-pass/" data-track-event="TopStoriesBlock,TopStoriesBlock,position3"><img src="https://twt-thumbs.washtimes.com/media/image/2014/12/02/122_2014_americanflagpasspor8201_c240-0-1040-800_s85x85.jpg?268321b9ecf14b86741a7ec893e279a0e7482210" width="85" height="85" alt="obj.0.content_object.caption" /></a>
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/quiz/2015/feb/11/us-citizenship-test-could-you-pass/" title="US Citizenship Test - Could You Pass?" data-track-event="TopStoriesBlock,TopStoriesBlock,position3" style="color: #000000;">Quiz: US Citizenship Test - Could You Pass?</a>
+	</h3>
+</article>
+
+
+
+
+
+
+<div class="OUTBRAIN" data-src="DROP_PERMALINK_HERE" data-widget-id="AR_4" data-ob-template="TheWashingtonTimes" ></div>
+<script type="text/javascript" async="async" src="//widgets.outbrain.com/outbrain.js"></script>
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2014/06/27/b3af08c0353e5219580f6a706700758c_c682-0-3514-2832_s85x85.jpg?9d204672712a78234add4c0ea6444fbcdd030cb1" width="85" height="85" alt="Gubernatorial hopeful and state Sen. Wendy Davis waves before speaking at the Dallas Convention Center during the Texas Democratic Convention in Dallas, Friday, June 27, 2014. (AP Photo/LM Otero)" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/31/wendy-davis-chip-roy-texas-house-race-promises-par/" title="&#8216;Nationalized, partisan and polarizing&#8217;: Return of liberal hero Wendy Davis sets up Texas slugfest" data-track-event="TopStoriesBlock,TopStoriesBlock,position5" style="color: #000000;">&#8216;Nationalized, partisan and polarizing&#8217;: Return of liberal hero Wendy Davis sets up Texas slugfest</a>
+	</h3>
+</article>
+
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2019/03/17/media_fox_pirro_55988_c203-0-1796-1593_s85x85.jpg?96b42e4078f52071be2934593c26714e39d1cd58" width="85" height="85"  />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/31/jeanine-pirro-fox-news-host-joins-board-of-cannabi/" title="Fox&#8217;s Jeanine Pirro joins board of cannabis company HeavenlyRx" data-track-event="TopStoriesBlock,TopStoriesBlock,position6" style="color: #000000;">Fox&#8217;s Jeanine Pirro joins board of cannabis company HeavenlyRx</a>
+	</h3>
+</article>
+
+
+
+
+
+<!-- templates/positions/render/ymal/massmedia_collection.html 6th August 2019 05:32 -->
+<!-- False 164541 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+      <!-- using primary image -->
+			<img src="https://twt-thumbs.washtimes.com/media/image/2019/07/24/SpringfieldArmoryXDM10mm4_5_c28-0-728-700_s85x85.jpg?68aab958e2246f1b8fc3f6e90af9a1659fe1f194" width="85" height="85" alt="SpringfieldArmoryXDM10mm4_5" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/multimedia/collection/instant-classics-best-new-handguns-2019/" title="Instant classics: best new handguns for 2019" data-track-event="TopStoriesBlock,TopStoriesBlock,position7" style="color: #000000;">Instant classics: best new handguns for 2019</a>
+	</h3>
+</article>
+
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2019/07/30/Election_2020_Debate_57427.jpg-9edd2_c919-0-2753-1834_s85x85.jpg?708f3e4c0496207a6949feb408816c61d78ca299" width="85" height="85" alt="From left, Marianne Williamson, Rep. Tim Ryan, D-Ohio, Sen. Amy Klobuchar, D-Minn., South Bend Mayor Pete Buttigieg, Sen. Bernie Sanders, I-Vt., Sen. Elizabeth Warren, D-Mass., former Texas Rep. Beto O&amp;#39;Rourke, former Colorado Gov. John Hickenlooper, former Maryland Rep. John Delaney and Montana Gov. Steve Bullock take the stage for the first of two Democratic presidential primary debates hosted by CNN Tuesday, July 30, 2019, in the Fox Theatre in Detroit. (AP Photo/Paul Sancya)" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/31/stephen-colbert-skewers-2020-democratic-field-too-/" title="Stephen Colbert skewers 2020 Democratic field: &#8216;Too many middle-aged generic white guys, man!&#8217;" data-track-event="TopStoriesBlock,TopStoriesBlock,position8" style="color: #000000;">Stephen Colbert skewers 2020 Democratic field: &#8216;Too many middle-aged generic white guys, man!&#8217;</a>
+	</h3>
+</article>
+
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2019/07/30/Screen_Shot_2019-07-30_at_2.08.28_PM_c226-0-753-527_s85x85.png?938263fbda19123814b13079bd761cd27d92087f" width="85" height="85" alt="Washington Times opinion editor and columnist Charles Hurt told Fox News on Tuesday that outrage over President Trump&amp;#39;s comments about Rep. Elijah Cummings, Maryland Democrat, were an example of Washington&amp;#39;s preoccupation with race. (Screen image from Fox News)" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/30/charles-hurt-hits-back-on-outrage-over-trumps-comm/" title="Charles Hurt hits back on outrage over Trump&#8217;s comments about Elijah Cummings" data-track-event="TopStoriesBlock,TopStoriesBlock,position9" style="color: #000000;">Charles Hurt hits back on outrage over Trump&#8217;s comments about Elijah Cummings</a>
+	</h3>
+</article>
+
+
+
+
+
+
+<div class="OUTBRAIN" data-src="DROP_PERMALINK_HERE" data-widget-id="AR_7" data-ob-template="TheWashingtonTimes" ></div>
+
+<script type="text/javascript" async="async" src="//widgets.outbrain.com/outbrain.js"></script>
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2019/07/26/Pelosi_AOC_49930.jpg-d9d07_c666-0-3333-2667_s85x85.jpg?c4ecced7793a37e68db6de3e40b2f1cd764999b5" width="85" height="85" alt="Rep. Alexandria Ocasio-Cortez, D-N.Y., attends a House Oversight Committee hearing on high prescription drugs prices shortly after her private meeting with Speaker of the House Nancy Pelosi, D-Calif., on Capitol Hill in Washington, Friday, July 26, 2019. The high-profile freshman and the veteran Pelosi have been critical of one another recently. (AP Photo/J. Scott Applewhite)" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/30/alexandria-ocasio-cortez-green-new-deal-cost-70k/" title="AOC&#8217;s Green New Deal would cost $70K-plus per household in first year: Study" data-track-event="TopStoriesBlock,TopStoriesBlock,position11" style="color: #000000;">AOC&#8217;s Green New Deal would cost $70K-plus per household in first year: Study</a>
+	</h3>
+</article>
+
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2019/07/30/AP_18360444164912_c1792-0-5299-3507_s85x85.jpg?d7be52e5ea78fd425f1270c5d8dca2ad11631c0a" width="85" height="85" alt="Russian Defense Minister Sergei Shoigu, fourth left, Russian President Vladimir Putin, fifth left, Chief of General Staff of Russia Valery Gerasimov, sixth left, and other top officials oversee the test launch of the Avangard hypersonic glide vehicle from the Defense Ministry&amp;#39;s control room in Moscow, Russia, Wednesday, Dec. 26, 2018. In the test, the Avangard was launched from the Dombarovskiy missile base in the southern Ural Mountains. The Kremlin says it successfully hit a designated practice target on the Kura shooting range on Kamchatka, 6,000 kilometers (3,700 miles) away. (Mikhail Klimentyev, Sputnik, Kremlin Pool Photo via AP)" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/30/hypersonic-weapons-threaten-render-american-milita/" title="Russia, China crushing U.S. in hypersonic weapons arms race " data-track-event="TopStoriesBlock,TopStoriesBlock,position12" style="color: #000000;">Russia, China crushing U.S. in hypersonic weapons arms race </a>
+	</h3>
+</article>
+
+
+
+
+
+<!-- templates/positions/render/ymal/quiz_quiz.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+			<a href="/quiz/2019/jul/11/can-pass-washington-dc-history-test/" data-track-event="TopStoriesBlock,TopStoriesBlock,position13"><img src="https://twt-thumbs.washtimes.com/media/image/2015/01/27/7a8dd6135c4e72046c0f6a7067007ed9_c1064-0-4850-3786_s85x85.jpg?8ca86bc15409d0b80d521d1c0ece0a8175cac91f" width="85" height="85" alt="obj.0.content_object.caption" /></a>
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/quiz/2019/jul/11/can-pass-washington-dc-history-test/" title="Can you pass a Washington, D.C. history test?" data-track-event="TopStoriesBlock,TopStoriesBlock,position13" style="color: #000000;">Quiz: Can you pass a Washington, D.C. history test?</a>
+	</h3>
+</article>
+
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2017/01/24/trump_78368_c1138-0-4174-3036_s85x85.jpg?5f15660f712c763243df5b9df575e02a94bb1879" width="85" height="85" alt="Vice President Mike Pence, left, and Secret Service Director Joseph Clancy stand as President Donald Trump shakes hands with FBI Director James Comey during a reception for inaugural law enforcement officers and first responders in the Blue Room of the White House, Sunday, Jan. 22, 2017 in Washington. (AP Photo/Alex Brandon)" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/30/john-ratcliffe-trump-dni-nominee-vows-expose-russi/" title="Top spy nominee vows to expose origins of FBI&#8217;s Trump-Russia probe" data-track-event="TopStoriesBlock,TopStoriesBlock,position14" style="color: #000000;">Top spy nominee vows to expose origins of FBI&#8217;s Trump-Russia probe</a>
+	</h3>
+</article>
+
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2019/07/29/Trump_Russia_Probe_34470.jpg-5c319_c966-0-4614-3648_s85x85.jpg?18eea158318f287320f71e52c3d87243364384ed" width="85" height="85" alt="Former special counsel Robert Mueller testifies before the House Intelligence Committee hearing on his report on Russian election interference, on Capitol Hill, in Washington, Wednesday, July 24, 2019. (AP Photo/Andrew Harnik)" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/30/impeachment-push-stalls-among-voters-quinnipiac-po/" title="&#8216;Minds were not changed&#8217;: Trump impeachment push stalls among voters after Mueller hearing" data-track-event="TopStoriesBlock,TopStoriesBlock,position15" style="color: #000000;">&#8216;Minds were not changed&#8217;: Trump impeachment push stalls among voters after Mueller hearing</a>
+	</h3>
+</article>
+
+
+
+
+
+<!-- templates/positions/render/ymal/massmedia_collection.html 6th August 2019 05:32 -->
+<!-- False 40474 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2014/11/25/1903-springfield_c83-0-549-466_s85x85.jpg?e04ffa19e291b8eaa40653c48e8660e92de11e8a" width="85" height="85" alt="1903-Springfield" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/multimedia/collection/best-combat-rifles-all-time/" title="Best combat rifles of all time" data-track-event="TopStoriesBlock,TopStoriesBlock,position16" style="color: #000000;">Best combat rifles of all time</a>
+	</h3>
+</article>
+
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2019/07/02/trump_california_homelessness_13486_c327-0-1399-1072_s85x85.jpg?942733426f4d321b54e04f651ef62008f1f49bd8" width="85" height="85" alt="This Monday, July 1, 2019 photo shows Los Angeles City Hall behind a homeless tent encampment along a street in downtown Los Angeles. Los Angeles Mayor Eric Garcetti wants President Donald Trump to visit the city and work with him on the homeless crisis. The Democratic mayor made the public invitation during a radio interview Tuesday, July 2, 2109, after the Republican president called the homeless crisis in Los Angeles, San Francisco and other big cities disgraceful and threatened to intercede. (AP Photo/Richard Vogel)" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/30/homeless-people-in-la-file-lawsuit-against-2016-cl/" title="Homeless people in L.A. file lawsuit against 2016 cleanup ordinance to protect private property" data-track-event="TopStoriesBlock,TopStoriesBlock,position17" style="color: #000000;">Homeless people in L.A. file lawsuit against 2016 cleanup ordinance to protect private property</a>
+	</h3>
+</article>
+
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2019/07/30/7_302019_financial-markets-wall-st-28201_c960-0-4800-3840_s85x85.jpg?13bf074dfe4acf2bdba7063d5010d65726956a62" width="85" height="85" alt="A security breach at Capital One Financial, one of the nation&amp;#39;s largest issuers of credit cards, compromised the personal information of about 106 million people, and in some cases the hacker obtained Social Security and bank account numbers. (ASSOCIATED PRESS)" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/30/capital-one-data-breach-tied-to-cloud-computing-vu/" title="Capital One data breach tied to cloud computing vulnerability" data-track-event="TopStoriesBlock,TopStoriesBlock,position18" style="color: #000000;">Capital One data breach tied to cloud computing vulnerability</a>
+	</h3>
+</article>
+
+
+
+
+
+<!-- templates/positions/render/ymal/quiz_quiz.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+			<a href="/quiz/2019/jul/25/can-you-pass-amazing-insects-test/" data-track-event="TopStoriesBlock,TopStoriesBlock,position19"><img src="https://twt-thumbs.washtimes.com/media/image/2019/01/26/exchange_missing_monarchs_42460_c1035-0-4335-3300_s85x85.jpg?5ec8bcd6c85eeea6e9f5e084ad42ae4a2ad457f1" width="85" height="85" alt="obj.0.content_object.caption" /></a>
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/quiz/2019/jul/25/can-you-pass-amazing-insects-test/" title="Can you pass the amazing insects test?" data-track-event="TopStoriesBlock,TopStoriesBlock,position19" style="color: #000000;">Quiz: Can you pass the amazing insects test?</a>
+	</h3>
+</article>
+
+
+
+
+
+
+
+
+
+
+<!-- templates/positions/render/ymal/stories_story.html 6th August 2019 05:32 -->
+<article class="article-position-render">
+	<div class="main-photo">
+
+			<img src="https://twt-thumbs.washtimes.com/media/image/2019/07/29/Trump_15446.jpg-1e9cd_c451-0-2655-2204_s85x85.jpg?2beb79f09f2b36e6768238ae6df8c0108c34fc16" width="85" height="85" alt="In this file photo from Wednesday, June 12, 2019, House Oversight and Reform Committee Chairman Elijah Cummings, D-Md., considers whether to hold Attorney General William Barr and Commerce Secretary Wilbur Ross in contempt over subpoenaed documents related to the Trump administration&amp;#39;s decision to add a citizenship question to the 2020 census, on Capitol Hill in Washington. In the latest rhetorical shot at lawmakers of color, Trump this weekend vilified Cummings&amp;#39; majority-black Baltimore district as a &amp;quot;disgusting, rat and rodent infested mess&amp;quot; where &amp;quot;no human being would want to live.&amp;quot; (AP Photo/J. Scott Applewhite, file)" />
+
+	</div>
+	<h3 class="page-headline" style="margin-top: 0;">
+		<a href="/news/2019/jul/29/donald-trumps-racist-tweets-highlight-troubled-us-/" title="Cities ravaged by social and economic ills run by Dems for decades" data-track-event="TopStoriesBlock,TopStoriesBlock,position20" style="color: #000000;">Cities ravaged by social and economic ills run by Dems for decades</a>
+	</h3>
+</article>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+              </div>
+            </section>
+            <!-- //.breaking-news -->
+
+
+
+        </section>
+      </div>
+    </div>
+  </section>
+
+<!-- //#content -->
+
+    </div>
+
+  </div><!-- END 3-column layout -->
+
+
+
+
+
+
+    <!-- Begin #footer -->
+    <footer id="footer">
+      <div class="footer-inner" style="padding-top: 30px;">
+
+        <div id="contact-links" class="container">
+          <div class="row">
+            <section class="block newsletter block-email-alerts-footer col-lg-13">
+	<div class="block-content">
+		<h3>Newsletters</h3>
+    <form action="/newsletters/boomtrain/subscribe/" method="post"  class="form-inline">
+
+			<ul>
+				<li><input type="checkbox" name="breaking_news" />&nbsp;Breaking News</li>
+        <li><input type="checkbox" name="newsletter_morning" />&nbsp;Daily</li>
+				<li><input type="checkbox" name="newsletter_sunday" />&nbsp;Weekly</li>
+        <li><input type="checkbox" name="newsletter_hurt" />&nbsp;Charles Hurt</li>
+        <li><input type="checkbox" name="newsletter_todays-opinion" />&nbsp;Today's Opinion</li>
+			</ul>
+			<div class="cb"></div>
+			<input type="text" name="email" class="Email" placeholder="Email Address" />
+			<input type="submit" value="Submit" />
+		</form>
+	</div>
+	<div class="cb"></div>
+	<p class="newsletter-small"><a href="/terms-of-use/">Terms of Use</a> / <a href="/privacy/">Privacy Policy</a></p>
+</section>
+
+            <section class="facebook-links col-sm-15 col-lg-7">
+              <div class="section-inner">
+                <h3>Find us on Facebook</h3>
+                <ul class="links">
+                  <li><a href="https://www.facebook.com/TheWashingtonTimes" title="The Washington Times" target="_blank">The Washington Times</a></li>
+                  <li><a href="https://www.facebook.com/WashingtonTimesOpinion/" title="Opinion" target="_blank">Opinion</a></li>
+                  <li><a href="https://www.facebook.com/WashingtonTimesLocal/" title="Local" target="_blank">Local</a></li>
+                  <li><a href="https://www.facebook.com/WashingtonTimesSports/" title="Sports" target="_blank">Sports</a></li>
+                </ul>
+              </div>
+            </section>
+            <section class="twitter-links col-sm-15 col-lg-10">
+              <div class="section-inner">
+                <h3>Find us on Twitter</h3>
+                <div class="container-fluid">
+                  <div class="row">
+                    <ul class="links">
+                      <li><a href="https://twitter.com/WashTimes" title="The Washington Times" target="_blank">The Washington Times</a></li>
+                      <li><a href="https://twitter.com/WashTimesOpEd" title="Opinion" target="_blank">Opinion</a></li>
+                      <li><a href="https://twitter.com/WashTimesLocal" title="Local" target="_blank">Local</a></li>
+                      <li><a href="https://twitter.com/WashTimesSports" title="Sports" target="_blank">Sports</a></li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+        <!-- //#contact-links -->
+
+
+
+
+
+        <nav id="footer-nav" role="navigation">
+          <div class="container">
+            <ul class="menu">
+              <li><a href="/subscribe/?subscribe-link-footer" title="Subscribe">Subscribe</a></li>
+              <li><a href="http://classified.washingtontimes.com" title="Classifieds" target="_blank">Classifieds</a></li>
+              <li><a href="https://washingtontimes-dc.newsmemory.com/?utm_source=washingtontimes&utm_medium=footer" title="E-edition" target="_blank">E-edition</a></li>
+              <li><a href="/customer-service/" title="Customer Service">Customer Service</a></li>
+              <li><a href="/about/jobs/" title="Careers">Careers</a></li>
+              <li><a href="/terms-of-use/" title="Terms">Terms</a></li>
+              <li><a href="/privacy/" title="Privacy">Privacy</a></li>
+              <li><a href="/feeds/" title="RSS">RSS</a></li>
+              <li><a href="/advertise/" title="Advertise">Advertise</a></li>
+              <li><a href="/faq/" title="FAQ">FAQ</a></li>
+              <li><a href="/about/" title="About">About</a></li>
+              <li><a href="/contact-us/" title="Contact">Contact</a></li>
+            </ul>
+          </div>
+        </nav>
+        <section id="colophon">
+          <div class="container">
+            <h6 class="vcard"><span class="copyright-info">All site contents <span title="full">&copy;</span> Copyright <span class="YYYY">2019</span>&nbsp;<span class="nowrap fn">The Washington Times, LLC</span> <span class="separator">|</span></span> <span class="address">3600 New York Avenue NE <span class="separator">|</span> Washington, DC 20002 <span class="separator">|</span> <span class="tel" data-vcard-tel="+12026363000">202-636-3000</span></span></h6>
+          </div>
+        </section>
+      </div>
+    </footer>
+    <!-- End #footer -->
+
+
+
+
+
+
+<script>
+    MODALOPTIONS = [];
+</script>
+
+
+
+
+
+  <div class="piano-fixed-footer-one"></div>
+  <div class="piano-fixed-footer-two"></div>
+
+
+  <!-- Begin Global Scripts -->
+  <script src="//twt-assets.washtimes.com/js/global.9124b0988b1c.js"></script>
+  <!--End Global Scripts -->
+
+  <script>
+    var isFBReferral = document.cookie.match('RefererIsFacebook=1');
+    if (isFBReferral) {
+      var flaggedElems = document.getElementsByClassName("do-not-display-flag");
+      var numItems = flaggedElems.length;
+      for (var i=0; i<numItems; i++) {
+        flaggedElems[0].remove();
+      }
+    }
+  </script>
+
+  <!-- Quantcast Tag -->
+<script type="text/javascript">
+  var _qevents = _qevents || [];
+
+  (function() {
+    var elem = document.createElement('script');
+    elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+    elem.async = true;
+    elem.type = "text/javascript";
+    var scpt = document.getElementsByTagName('script')[0];
+    scpt.parentNode.insertBefore(elem, scpt);
+  })();
+
+  _qevents.push({
+    qacct:"p-c69_1G6fdlihY"
+  });
+</script>
+
+<noscript>
+  <div style="display:none;">
+    <img src="//pixel.quantserve.com/pixel/p-c69_1G6fdlihY.gif" border="0" height="1" width="1" alt="Quantcast"/>
+  </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+<!-- BEGIN Google Code for Remarketing Tag -->
+<script type="text/javascript">
+/* <![CDATA[ */
+var google_conversion_id = 878499686;
+var google_custom_params = window.google_tag_params;
+var google_remarketing_only = true;
+/* ]]> */
+</script>
+<script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js"></script>
+<noscript>
+<div style="display:inline;"><img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/878499686/?guid=ON&amp;script=0"/></div>
+</noscript>
+<!-- END Google Code for Remarketing Tag -->
+
+
+
+
+
+
+  <script>
+    tp = window.tp || [];
+    tp.push(["setContentAuthor", "Associated Press"]);         // The content author
+    tp.push(["setContentSection", "News"]);       // The content section
+    tp.push(["setTags", ["News"]]);                 // The content tags
+    tp.push(["setZone", "Web"]);                           // Zone can be an AAM platform or section of your site
+</script>
+
+
+  <script type="text/javascript">
+
+    function loadOutbrain() {
+      $('.GRAYMATTER-DELAY').addClass('OUTBRAIN').removeClass('GRAYMATTER-DELAY');
+      if (window.OBR) {
+        // if script is already loaded, this will trigger the ads to load
+        OBR.extern.researchWidget();
+      } else {
+        $.getScript("//widgets.outbrain.com/outbrain.js");
+      }
+    }
+
+
+    /**
+     *
+     * @type {jQuery.fn.init|Window.jQuery.fn.init|jQuery|HTMLElement}
+     */
+    var $bigTextPag = $('.bigtext > p');
+
+    var ShowCount = 7;
+
+    function layoutArticle() {
+
+      var animspeed = 900; // animation speed in milliseconds
+
+      var $blockquote = $('.bigtext');  // container for the paragraphs to be displayed
+      var height = $blockquote.height();
+      var mini = 0;
+
+      // determines how many paragraphs are shown
+      for (var i=0; i<ShowCount; i++){
+        console.log("PARA:", $bigTextPag.eq(i));
+        mini += $bigTextPag.eq(i).outerHeight();
+      }
+      // add in Connatix video player
+      mini += 405;
+
+      $blockquote.attr('data-fullheight', height + 'px');
+      $blockquote.attr('data-miniheight', mini + 'px');
+      $blockquote.css('height', mini + 'px');
+
+      $('.expand').on('click', function (e) {
+        _gaq.push(['_trackPageview', location.pathname + '#read-more']);
+        var $text = $('div.bigtext');
+
+        $text.animate({
+          'height': $text.attr('data-fullheight')
+        }, animspeed, null, function () {
+          $text.height('inherit');
+        });
+
+        var fromFacebook = Cookies.get('RefererIsFacebook');
+        if (fromFacebook) {
+          $('.do-not-display-flag').hide();
+        }
+
+        $(this).next('.contract').removeClass('hide');
+        $(this).addClass('hide');
+        $('.read-more-show').removeClass('hide');
+        loadOutbrain();
+      });
+
+      // used by the Print button to expand all content for printing
+      $('.expand-comments').on('click', function (e) {
+        $('.bigtext').height('inherit');
+        $('.expand').addClass('hide');
+        $('.contract').removeClass('hide');
+        $('.read-more-show').removeClass('hide');
+        loadOutbrain();
+      });
+
+      $('.contract').on('click', function (e) {
+        var $text = $('div.bigtext');
+        $text.animate({
+          'height': $text.attr('data-miniheight')
+        }, animspeed);
+        $(this).prev('.expand').removeClass('hide');
+        $(this).addClass('hide');
+        $('.read-more-show').addClass('hide');
+
+      });
+
+    }
+
+    /**
+     * Show more article text and the comments panel on
+     * "Click to read more and comments" hide that link
+     *
+     * NOTE: when `ShowCount` or less <p> are set on the content, don't show the
+     *       expand/hide link. There's one extra <p> hard-coded on the
+     *       template after the comments for spacing purposes.
+     */
+    if ($bigTextPag.length < ShowCount + 1) {
+      $('.expand').hide();
+    } else {
+      layoutArticle();
+    }
+
+  </script>
+
+  <script src="https://s.newsmaxfeednetwork.com/static/js/connectV5.js"></script>
+  <script type="text/javascript">
+    NM.init({
+      widgetId: "L6Wh6EinvOZMP2dyoJbbAZuYVrZdC69gbJAHMH6l",
+      template: "NM07"
+    });
+  </script>
+
+  <script type="text/javascript">
+    var fby = fby || [];
+    fby.push(['showTab', {id: '11340', position: 'right', color: '#A2182C'}]);
+    (function () {
+      var f = document.createElement('script');
+      f.type = 'text/javascript';
+      f.async = true;
+      f.src = '//cdn.feedbackify.com/f.js';
+      var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(f, s);
+    })();
+  </script>
+
+
+
+
+
+  <script>
+    (function(src){var a=document.createElement("script");a.type="text/javascript";a.async=true;a.src=src;var b=document.getElementsByTagName("script")[0];b.parentNode.insertBefore(a,b)})("//experience.tinypass.com/xbuilder/experience/load?aid=hph4LAYuC6");
+  </script>
+
+<script>
+  tp = window.tp || [];
+  console.log('TP setUsePianoIdUserProvider');
+  tp.push(["setUsePianoIdUserProvider", true ]);         // Piano ID Initialization
+
+
+</script>
+
+
+
+</body>
+</html>

--- a/tests/site_test_data/washingtontimes.com/article-3_extracted_data.json
+++ b/tests/site_test_data/washingtontimes.com/article-3_extracted_data.json
@@ -1,0 +1,14 @@
+{
+    "site_name": "washingtontimes.com",
+    "article_url": "https://www.washingtontimes.com/news/2019/jul/8/police-say-9-year-old-boy-had-stolen-car-that-hit-/",
+    "title": "Police say 9-year-old boy had stolen car that hit house",
+    "byline": null,
+    "publication_datetime": "2019-07-08T00:00:00",
+    "plain_content": "<div><div><p>GRAND ISLAND, Neb. (AP) - Police have cited a 9-year-old boy who officers say stole a car, lost control of it and crashed into a Grand Island house.</p><p>A neighbor of the boy reported the car stolen Sunday night. Police spotted it but didn’t start a chase. It went out of control and ran through several yards before hitting the house.</p><p>Police say the boy wasn’t hurt and refused to get out of the car. Officers who broke in and took him out say he spit on them and used racial slurs. Police also say the boy had a knife on him.</p><p>He was cited for flight to avoid arrest, theft and other crimes.</p></div></div>",
+    "plain_text": [
+      {"text": "GRAND ISLAND, Neb. (AP) - Police have cited a 9-year-old boy who officers say stole a car, lost control of it and crashed into a Grand Island house."},
+      {"text": "A neighbor of the boy reported the car stolen Sunday night. Police spotted it but didn’t start a chase. It went out of control and ran through several yards before hitting the house."},
+      {"text": "Police say the boy wasn’t hurt and refused to get out of the car. Officers who broke in and took him out say he spit on them and used racial slurs. Police also say the boy had a knife on him."},
+      {"text": "He was cited for flight to avoid arrest, theft and other crimes."}
+    ]
+}


### PR DESCRIPTION
Closes #198 

Only potential downside of this change is that we are no longer only getting the politics category. We  were previously only crawling ~60 articles, but now crawler running indefinitely, I stopped at 485:

```
2019-08-06 11:04:29     INFO: Processed 485 pages in 0:02:33.039399 => 3.17 Hz
2019-08-06 11:04:29     INFO: Found articles in 485/485 pages => 100.00%
2019-08-06 11:04:29     INFO: ... of these 0/485 had no date => 0.00%
2019-08-06 11:04:29     INFO: ... of these 290/485 had no byline => 59.79%
2019-08-06 11:04:29     INFO: ... of these 0/485 had no title => 0.00%
2019-08-06 11:04:29     INFO: Including skipped pages, there are articles in 485/485 pages => 100.00%
```

I've checked and many articles have no bylines